### PR TITLE
Documentation modification

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,7 +1,9 @@
 # FAQ
 
 ## Does Kapowarr support XYZ?
+
 "XYZ" can be "Magazines" or "Manga" or something else. For now, there is a simple answer: if it can be found on ComicVine, you can add it to Kapowarr (and use features like renaming and unzipping). If getcomics offers downloads for it, you can also download for it.
 
 ## When will XYZ be added?
+
 "XYZ" can be "Library Import" or "Exporting metadata" or something else. First, check out the [project board](https://github.com/users/Casvt/projects/5) to see if it's already on there and if so, at what stage it is. If it's not, check if a feature request is already made for it on the [issues page](https://github.com/Casvt/Kapowarr/issues) and otherwise make a feature request for it there.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,11 +21,13 @@ General Information:
 - [API Docs](./api.md)
 
 ## Workings
+
 Kapowarr allows you to build a digital library of comics. You can add volumes, map them to a folder and start managing! Download issues of the volume (or TPB's), rename them and move them. The whole process is automated and is all customizable in the settings.
 
 Each day, each volume is checked to see if a new issue has come out and if so, it will immediately be downloaded and added to your library.
 
 ## Features
+
 - Get loads of metadata about the volumes and issues in your library
 - Run a "Search Monitored" to download whole volumes with one click
 - Or use "Manual Search" to decide yourself what to download
@@ -35,5 +37,6 @@ Each day, each volume is checked to see if a new issue has come out and if so, i
 - The recognizable UI from the *arr suite of software
 
 ## Contact
+
 - For support, a [discord server](https://discord.gg/nMNdgG7vsE) is available
 - Alternatively, [make an issue](https://github.com/Casvt/Kapowarr/issues)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,6 +20,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
 	2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
 	3. You can map multiple root folders by repeating `-v /path/to/root_folder:/content` in the command, but then supplying different values for `/path/to/root_folder` and `/content`.
 	4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
+	5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes)).
 
 === "Docker Compose"
 	The contents of the docker-compose.yml file would look like this:
@@ -42,6 +43,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
 	2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
 	3. You can map multiple root folders by repeating `- /path/to/root_folder:/content` in the file, but then supplying different values for `/path/to/root_folder` and `/content`.
 	4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
+	5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes))
 
 ### Docker example
 === "Docker CLI"
@@ -73,6 +75,24 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
 	```
 
 In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.
+
+### Named volumes
+=== "Docker CLI"
+    ```bash
+    docker volume create kapowarr-db
+    ```
+
+=== "Portainer"
+    - Open `Volumes`
+    - Click `Add Volume`
+    - Enter name matching the one you'll use in compose (`kapowarr-db`, in the above example)
+    - Click `Create the volume`
+    - Open `Stacks`
+    - Create the stack with the named volume in it.
+
+Both of these options will create a named volume that you can then use in the examples above.  
+If you'd prefer to use a local folder on the host machine for storing config, Linux standards would suggest putting that in `/opt/application_name`, as the `/opt` directory is where program options should be stored. 
+In this case, you'd create the desired folder with something like `mkdir /opt/kapowarr/db`, and replace 'kapowarr-db:/app/db' with '/opt/kapowarr/db:/app/db'.
 
 ## Manual Install
 Coming soon

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,80 +3,83 @@
 The recommended way to install Kapowarr is using Docker. After installing Kapowarr, it is advised to read the [Setup After Installation page](./setup_after_installation.md).
 
 ## Docker
-=== "Docker CLI"
-	The command to get the docker container running can be found below:
-	```bash
-	docker run -d \
-		--name kapowarr \
-		-v kapowarr-db:/app/db \
-		-v /path/to/download_folder:/app/temp_downloads \
-		-v /path/to/root_folder:/content \
-		-p 5656:5656
-		mrcas/kapowarr:latest
-	```
-	A few notes about this command:
 
-	1. Replace `/path/to/download_folder` with the path to your desired download folder. Everything is downloaded to this folder and when completed, moved out of to their final destination. It's smart to set this on a disk that can sustain more writes than normal. Ideally something like a _non_-network mounted ssd.
-	2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
-	3. You can map multiple root folders by repeating `-v /path/to/root_folder:/content` in the command, but then supplying different values for `/path/to/root_folder` and `/content`.
-	4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
-	5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes)).
+=== "Docker CLI"
+    The command to get the docker container running can be found below:
+    ```bash
+    docker run -d \
+        --name kapowarr \
+        -v kapowarr-db:/app/db \
+        -v /path/to/download_folder:/app/temp_downloads \
+        -v /path/to/root_folder:/content \
+        -p 5656:5656
+        mrcas/kapowarr:latest
+    ```
+    A few notes about this command:
+
+    1. Replace `/path/to/download_folder` with the path to your desired download folder. Everything is downloaded to this folder and when completed, moved out of to their final destination. It's smart to set this on a disk that can sustain more writes than normal. Ideally something like a _non_-network mounted ssd.
+    2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
+    3. You can map multiple root folders by repeating `-v /path/to/root_folder:/content` in the command, but then supplying different values for `/path/to/root_folder` and `/content`.
+    4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
+    5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes)).
 
 === "Docker Compose"
-	The contents of the docker-compose.yml file would look like this:
-	```yml
-	version: '3.3'
-	services:
-		kapowarr:
-			container_name: kapowarr
-			volumes:
-				- 'kapowarr-db:/app/db'
-				- '/path/to/download_folder:/app/temp_downloads'
-				- '/path/to/root_folder:/content'
-			ports:
-				- '5656:5656'
-			image: 'mrcas/kapowarr:latest'
-	```
-	A few notes about this file:
+    The contents of the docker-compose.yml file would look like this:
+    ```yml
+    version: '3.3'
+    services:
+        kapowarr:
+            container_name: kapowarr
+            volumes:
+                - 'kapowarr-db:/app/db'
+                - '/path/to/download_folder:/app/temp_downloads'
+                - '/path/to/root_folder:/content'
+            ports:
+                - '5656:5656'
+            image: 'mrcas/kapowarr:latest'
+    ```
+    A few notes about this file:
 
-	1. Replace `/path/to/download_folder` with the path to your desired download folder. Everything is downloaded to this folder and when completed, moved out of to their final destination. It's smart to set this on a disk that can sustain more writes than normal. Ideally something like a _non_-network mounted ssd.
-	2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
-	3. You can map multiple root folders by repeating `- /path/to/root_folder:/content` in the file, but then supplying different values for `/path/to/root_folder` and `/content`.
-	4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
-	5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes))
+    1. Replace `/path/to/download_folder` with the path to your desired download folder. Everything is downloaded to this folder and when completed, moved out of to their final destination. It's smart to set this on a disk that can sustain more writes than normal. Ideally something like a _non_-network mounted ssd.
+    2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
+    3. You can map multiple root folders by repeating `- /path/to/root_folder:/content` in the file, but then supplying different values for `/path/to/root_folder` and `/content`.
+    4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
+    5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes))
 
 ### Docker example
+
 === "Docker CLI"
-	```bash
-	docker run -d \
-		--name kapowarr \
-		-v kapowarr-db:/app/db \
-		-v /home/cas/media/Downloads:/app/temp_downloads \
-		-v /home/cas/media/Comics:/RF \
-		-v /home/cas/media/Comics-2:/RF-2 \
-		-p 5656:5656
-		mrcas/kapowarr:latest
-	```
+    ```bash
+    docker run -d \
+        --name kapowarr \
+        -v kapowarr-db:/app/db \
+        -v /home/cas/media/Downloads:/app/temp_downloads \
+        -v /home/cas/media/Comics:/RF \
+        -v /home/cas/media/Comics-2:/RF-2 \
+        -p 5656:5656
+        mrcas/kapowarr:latest
+    ```
 
 === "Docker Compose"
-	```yml
-	version: '3.3'
-	services:
-		kapowarr:
-			container_name: kapowarr
-			volumes:
-				- 'kapowarr-db:/app/db'
-				- '/home/cas/media/Downloads:/app/temp_downloads'
-				- '/home/cas/media/Comics:/RF'
-				- '/home/cas/media/Comics-2:/RF-2'
-			ports:
-				- '5656:5656'
-			image: 'mrcas/kapowarr:latest'
-	```
+    ```yml
+    version: '3.3'
+    services:
+        kapowarr:
+            container_name: kapowarr
+            volumes:
+                - 'kapowarr-db:/app/db'
+                - '/home/cas/media/Downloads:/app/temp_downloads'
+                - '/home/cas/media/Comics:/RF'
+                - '/home/cas/media/Comics-2:/RF-2'
+            ports:
+                - '5656:5656'
+            image: 'mrcas/kapowarr:latest'
+    ```
 
 In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.
 
 ### Named volumes
+
 === "Docker CLI"
     ```bash
     docker volume create kapowarr-db
@@ -95,5 +98,5 @@ If you'd prefer to use a local folder on the host machine for storing config, Li
 In this case, you'd create the desired folder with something like `mkdir /opt/kapowarr/db`, and replace 'kapowarr-db:/app/db' with '/opt/kapowarr/db:/app/db'.
 
 ## Manual Install
-Coming soon
 
+Coming soon

--- a/docs/rate_limiting.md
+++ b/docs/rate_limiting.md
@@ -1,10 +1,13 @@
 # Rate limiting
+
 This page covers how Kapowarr handles with the rate limits of services it uses.
 
 ## ComicVine
+
 Hourly, Kapowarr finds the volumes that haven't had a metadata fetch for more than a day. It tries to fetch for as many volumes as possible. If it can't fetch for them all in one go, the ones that didn't get fetched, get preference the next hour. For the fetched volumes, Kapowarr checks when the last time was that the metadata was updated and compares it to it's stored date. If it determines that the metadata for the volume has been updated since the last fetch, it applies the fetched metadata for the volume and fetches the metadata for all issues of the volume and apply that too.
 
 With this setup, all volumes (unless you have an absurdly big library) get updated every day and as little as possible requests are made. When we still surpass the limit, the volumes that need to fetched the most (the ones that haven't been updated for the longest) get preference to ensure that they "keep up". With this setup, worst case scenario, 25.000 volumes and 25.000 issues can be updated per hour. However, because metadata of a volume doesn't get updated often, Kapowarr only needs to update a few volumes _per day_, assuming you have a library of a few thousand volumes.
 
 ## Mega
+
 If a Mega download reaches the rate limit of the account mid-download (no way to calculate this beforehand), the download is canceled and all other Mega downloads in the download queue are removed. From that point on, Mega downloads are skipped until we can download from it again. Alternative services like MediaFire and GetComics are used instead of Mega while we wait for the limit to go down again. If you have a Mega account that offers higher limits, it's advised to add it at Settings -> Download -> Credentials, so that Kapowarr can take advantage of it.

--- a/docs/setup_after_installation.md
+++ b/docs/setup_after_installation.md
@@ -6,16 +6,16 @@ After installing Kapowarr, you should have access to the web-ui. Kapowarr needs 
 The first thing to do is decide if you want to leave Kapowarr on the default port of 5656. If you _do_, you can go to the next step. If you want to _change_ the port, continue reading.
 
 === "Docker CLI"
-	Alter the command to run the container and replace `-p 5656:5656` with `-p 5656:{PORT}`, where `{PORT}` is the desired port (e.g. `-p 5656:8009`). Then run the container with the new version of the command.
+	Alter the command to run the container and replace `-p 5656:5656` with `-p {PORT}:5656`, where `{PORT}` is the desired port (e.g. `-p 8009:5656`). Then run the container with the new version of the command.
 
 === "Docker Compose"
-	Alter the file to run the container and replace `- 5656:5656` with `- 5656:{PORT}`, where `{PORT}` is the desired port (e.g. `- 5656:8009`). Then run the container with the new version of the file.
+	Alter the file to run the container and replace `- 5656:5656` with `- {PORT}:5656`, where `{PORT}` is the desired port (e.g. `- 8009:5656`). Then run the container with the new version of the file.
 
 === "Manual Install"
 	Edit the port number at Settings -> General -> Host -> Port Number in the web-ui and change the value to the desired port. Then, restart Kapowarr.
 
 ## Authentication
-You might want to set a password to restrain access to the web-ui (and API). Setting a password is optional. A password can be set at Settings -> General -> Security -> Login Password. Don't forget to save. From then on, it is required to enter a password in order to gain access to the web-ui (and the API). If you want to disable the password, set an empty value for the setting and save.
+You might want to set a password to restrict access to the web-ui (and API). Setting a password is optional. A password can be set at Settings -> General -> Security -> Login Password. Don't forget to save. From then on, it is required to enter a password in order to gain access to the web-ui (and the API). If you want to disable the password, set an empty value for the setting and save.
 
 ## ComicVine API key
 Kapowarr uses ComicVine as it's metadata source. To fetch the metadata from ComicVine, Kapowarr needs access to the API, which requires an API key.

--- a/docs/setup_after_installation.md
+++ b/docs/setup_after_installation.md
@@ -3,21 +3,24 @@
 After installing Kapowarr, you should have access to the web-ui. Kapowarr needs some configuration in order for it to work properly.
 
 ## Port
+
 The first thing to do is decide if you want to leave Kapowarr on the default port of 5656. If you _do_, you can go to the next step. If you want to _change_ the port, continue reading.
 
 === "Docker CLI"
-	Alter the command to run the container and replace `-p 5656:5656` with `-p {PORT}:5656`, where `{PORT}` is the desired port (e.g. `-p 8009:5656`). Then run the container with the new version of the command.
+    Alter the command to run the container and replace `-p 5656:5656` with `-p {PORT}:5656`, where `{PORT}` is the desired port (e.g. `-p 8009:5656`). Then run the container with the new version of the command.
 
 === "Docker Compose"
-	Alter the file to run the container and replace `- 5656:5656` with `- {PORT}:5656`, where `{PORT}` is the desired port (e.g. `- 8009:5656`). Then run the container with the new version of the file.
+    Alter the file to run the container and replace `- 5656:5656` with `- {PORT}:5656`, where `{PORT}` is the desired port (e.g. `- 8009:5656`). Then run the container with the new version of the file.
 
 === "Manual Install"
-	Edit the port number at Settings -> General -> Host -> Port Number in the web-ui and change the value to the desired port. Then, restart Kapowarr.
+    Edit the port number at Settings -> General -> Host -> Port Number in the web-ui and change the value to the desired port. Then, restart Kapowarr.
 
 ## Authentication
+
 You might want to set a password to restrict access to the web-ui (and API). Setting a password is optional. A password can be set at Settings -> General -> Security -> Login Password. Don't forget to save. From then on, it is required to enter a password in order to gain access to the web-ui (and the API). If you want to disable the password, set an empty value for the setting and save.
 
 ## ComicVine API key
+
 Kapowarr uses ComicVine as it's metadata source. To fetch the metadata from ComicVine, Kapowarr needs access to the API, which requires an API key.
 
 1. Go to [the API page of ComicVine](https://comicvine.gamespot.com/api/).
@@ -28,27 +31,34 @@ Kapowarr uses ComicVine as it's metadata source. To fetch the metadata from Comi
 On the documentation page about [rate limiting](./rate_limiting.md), information can be found about the handling of the ComicVine API rate limit.
 
 ## Root Folders
+
 Root folders are the base folders that Kapowarr works in. All content is put in these folders. When adding a volume (or when editing one), you choose in which root folder all content for that volume is put. Kapowarr will never touch any files outside the root folders (except in the [download folder](#download-folder)). You might have multiple root folders because you store your comics on multiple drives or want different access rights to certain volumes, to name a few reasons.
 
 Root folders can be added at Settings -> Media Management -> Root Folders. Note: If you use docker to run Kapowarr and have followed the example given in the [installation instructions](./installation.md#docker), this is where you would enter `/content`, `/content2`, `/RF`, `/RF2`, etc.
 
 ## Downloading
+
 One of Kapowarr's biggest features is being able to download comics. The Settings -> Download section has all settings regarding the downloading.
 
 ### Download folder
+
 The download folder (Settings -> Download -> Download Location -> Direct Download Temporary Folder) is where all downloads are downloaded to, before they get moved to their final destination. If you run Kapowarr using Docker, leave this setting to it's default value of `/app/temp_downloads` and instead change the value of `/path/to/download_folder` in the Docker command ([reference](./installation.md#docker)). If you have a manual install, you can change this value to whatever you want. It is allowed to be outside your root folders.
 
 ### Service preference
+
 Kapowarr has the ability to download directly from servers, but also to download from services like MediaFire and Mega. Websites like getcomics.org offer the same download via multiple services (multiple download links to download the same file, via different services). This settings determines what preference you have for each service. If multiple services are offered for the same download, Kapowarr will use this preference list to determine what service to pick (if the link of the top service doesn't work, Kapowarr falls back to the other options, in order). If you have an account for one of these services (see [Credentials](#credentials) setting), you might want to put that one at the top, to make Kapowarr take advantage of the extra features that the account offers (extra bandwidth, higher rate limit, etc.).
 
 ### Credentials
+
 Kapowarr has the ability to download from services like MediaFire and Mega. These services apply limits to how much you can download per day, or a download speed limit. An (paid) account for one of these services often offers higher limits. Kapowarr can take advantage of these extra features that these accounts offer. Under the credentials section, you can add credentials of accounts, which Kapowarr will use when downloading, taking advantage of the extra features. 
 
 ## Building up a library
+
 Now you're ready to build a library. At Volumes -> Add Volume, you can search for volumes and add them to your library. Once you add one, a folder is automatically created for the volume in the root folder selected (see Settings -> Media Management -> File Naming -> Volume Folder Naming). Then you can start downloading content for the volume, and all files will be put in this volume folder. The naming of the files follows the format set in the settings (see Settings -> Media Management -> File Naming).
 
-??? Unzipping
-	Kapowarr has unzipping built-in. This means that it can extract zip files, filter the content to find the files that are actually desired, delete the other files, move the files to the correct location and name them correctly, delete the zip folder and delete the zip file. This can be done automatically for all downloaded zip files by enabling Settings -> Media Management -> Unzipping -> Unzip downloads. Unzipping can also be done for all zip files of a volume by pressing the "Unzip" button when viewing a volume.
+### Unzipping
+
+Kapowarr has unzipping built-in. This means that it can extract zip files, filter the content to find the files that are actually desired, delete the other files, move the files to the correct location and name them correctly, delete the zip folder and delete the zip file. This can be done automatically for all downloaded zip files by enabling Settings -> Media Management -> Unzipping -> Unzip downloads. Unzipping can also be done for all zip files of a volume by pressing the "Unzip" button when viewing a volume.
 
 Importing an already existing library into Kapowarr is currently not very fluid (the "Library Import" feature found in Radarr/Sonarr is not yet implemented in Kapowarr). The advised way to get Kapowarr working with your current library:
 


### PR DESCRIPTION
- Added notes about creating a named volume both from CLI and from Portainer
- Amended docker ports to correct `host:container` structure (rather than `container:host`, as it was)
- Linted markdown headers (all headings should have blank line between them and content)
- Linted markdown hard tabs (in markdown, a tab should be 4 spaces rather than a tab character, for clean conversion to HTML).