### PR TITLE
Docker env variable

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-casvantijn@gmail.com.
+`casvantijn@gmail.com`.
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -116,13 +116,11 @@ the community.
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
 version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+[https://www.contributor-covenant.org/version/2/0/code_of_conduct.html](https://www.contributor-covenant.org/version/2/0/code_of_conduct.html).
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
 [homepage]: https://www.contributor-covenant.org
 
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq).  
+Translations are available at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations).

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -2,10 +2,12 @@
 
 FROM python:3.8-slim-buster
 
-WORKDIR /app
-
 ENV PUID 1000
 ENV PGID 1000
+
+USER PUID:PGID
+
+WORKDIR /app
 
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -4,6 +4,9 @@ FROM python:3.8-slim-buster
 
 WORKDIR /app
 
+ENV PUID 1000
+ENV PGID 1000
+
 COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -2,10 +2,18 @@
 
 FROM python:3.8-slim-buster
 
+ARG USER=kapowarr
+
 ENV PUID 1000
 ENV PGID 1000
 
-USER PUID:PGID
+RUN groupadd -g $PGID -o $USER
+RUN useradd -m -N -u $PUID -g $PGID $USER && \
+echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers && \
+chmod 0440 /etc/sudoers && \
+chmod g+w /etc/passwd
+
+USER $USER
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
 # Kapowarr
+
 [![Docker Pulls](https://img.shields.io/docker/pulls/mrcas/kapowarr.svg)](https://hub.docker.com/r/mrcas/kapowarr)
 [![GitHub Downloads](https://img.shields.io/github/downloads/Casvt/Kapowarr/total.svg)](https://github.com/Casvt/Kapowarr/releases)
 
 Kapowarr is a software to build and manage a comic book library, fitting in the *arr suite of software.
 
 ## Workings
+
 Kapowarr allows you to build a digital library of comics. You can add volumes, map them to a folder and start managing! Download issues of the volume (or TPB's), rename them and move them. The whole process is automised and is all customisable in the settings.
 
 Each day, each volume is checked to see if a new issue has come out and if so, it will immediately be downloaded and added to your library.
 
 ## Features
+
 - Import your current library right into Kapowarr
 - Get loads of metadata about the volumes and issues in your library
 - Run a "Search Monitored" to download whole volumes with one click
@@ -20,11 +23,13 @@ Each day, each volume is checked to see if a new issue has come out and if so, i
 - The recognisable UI from the *arr suite of software
 
 ## Installation, support and documentation
+
 - For instructions on how to install Kapowarr, see the [installation documentation](https://casvt.github.io/Kapowarr/installation/).
 - For support, a [discord server](https://discord.gg/nMNdgG7vsE) is available or [make an issue](https://github.com/Casvt/Kapowarr/issues).
 - For all documentation, see the [documentation hub](https://casvt.github.io/Kapowarr/).
 
 ## Screenshots
+
 <img src="https://github.com/Casvt/Kapowarr/assets/88994465/797a7f2d-b279-4e21-8b99-c03e99065949" style="width: max(45%, 400px); margin: .5rem;">
 <img src="https://github.com/Casvt/Kapowarr/assets/88994465/71465b08-03eb-477e-a511-f5bc5d953447" style="width: max(45%, 400px); margin: .5rem;">
 <img src="https://github.com/Casvt/Kapowarr/assets/88994465/b21ae416-1ae4-46f1-8f63-cca21cc4ee7e" style="width: max(45%, 400px); margin: .5rem;">

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,33 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
     4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
     5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes))
 
+=== "Docker Compose (custom user)"
+    The contents of the docker-compose.yml file would look like this:
+    ```yml
+    version: '3.3'
+    services:
+        kapowarr:
+            container_name: kapowarr
+            volumes:
+                - 'kapowarr-db:/app/db'
+                - '/path/to/download_folder:/app/temp_downloads'
+                - '/path/to/root_folder:/content'
+            environment:
+                - PUID: 1000
+                - PGID: 1000
+            ports:
+                - '5656:5656'
+            image: 'mrcas/kapowarr:latest'
+    ```
+    A few notes about this file:
+
+    1. Replace `/path/to/download_folder` with the path to your desired download folder. Everything is downloaded to this folder and when completed, moved out of to their final destination. It's smart to set this on a disk that can sustain more writes than normal. Ideally something like a _non_-network mounted ssd.
+    2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
+    3. You can map multiple root folders by repeating `- /path/to/root_folder:/content` in the file, but then supplying different values for `/path/to/root_folder` and `/content`.
+    4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
+    5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes))
+    6. If you define a custom PUID and GUID here, they must have permission on any folder you've mapped in. The default user ID of '1000' is the first non-root user created on any Debian-based system, and generally exists on the host. If you are unsure of the _UID_ of the user you'd like the container to present as, see [Custom User](#custom-user).
+
 ### Docker example
 
 === "Docker CLI"
@@ -78,6 +105,28 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
 
 In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.
 
+=== "Docker Compose (custom user)"
+    ```yml
+    version: '3.3'
+    services:
+        kapowarr:
+            container_name: kapowarr
+            volumes:
+                - 'kapowarr-db:/app/db'
+                - '/home/cas/media/Downloads:/app/temp_downloads'
+                - '/home/cas/media/Comics:/RF'
+                - '/home/cas/media/Comics-2:/RF-2'
+            environment:
+                - PUID: 1000
+                - PGID: 1000
+            ports:
+                - '5656:5656'
+            image: 'mrcas/kapowarr:latest'
+    ```
+
+In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.  
+We also have Kapowarr running with a user that has the user ID 1000 (the default non-root user for a linux server). If you have a user that has less permission than root that you'd like Kapowarr to run as, you'd define their user ID and group ID here.
+
 ### Named volumes
 
 === "Docker CLI"
@@ -96,6 +145,30 @@ In this example, we set `/home/cas/media/Downloads` as the download folder and w
 Both of these options will create a named volume that you can then use in the examples above.  
 If you'd prefer to use a local folder on the host machine for storing config, Linux standards would suggest putting that in `/opt/application_name`, as the `/opt` directory is where program options should be stored. 
 In this case, you'd create the desired folder with something like `mkdir /opt/kapowarr/db`, and replace 'kapowarr-db:/app/db' with '/opt/kapowarr/db:/app/db'.
+
+### Custom User
+
+If you want to have Kapowarr run as a user other than root (for file permissions, or security purposes), you will need the user ID.  
+For a custom _group_, the same applies, but the group ID instead.  
+
+=== "Ubuntu"
+    User ID: `id -u <username>`  
+    Replace '<username>' with the actual username you'd like it to run as.  
+    Group ID: `id -g <username>`  
+    Replace '<username>' with the actual username you'd like to find the group of.
+
+=== "Debian"
+    User ID: `id -u <username>`  
+    Replace '<username>' with the actual username you'd like it to run as.  
+    Group ID: `id -g <username>`  
+    Replace '<username>' with the actual username you'd like to find the group of.
+
+=== "TrueNAS"
+    User ID: In the web UI, go to Credentials -> Local Users.  
+    Find the relevant username you'd like to use, and look at the 'UID' column to find the UID.
+    Group ID: In the web UI, go to Credentials -> Local Groups.  
+    Find the relevant group you'd like to use, and look at the 'GID' column to find the GID.
+
 
 ## Manual Install
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,7 +52,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
     docker run -d \
         --name kapowarr \
         -e PUID:1000 \
-        -e GUID:1000 \
+        -e PGID:1000 \
         -v kapowarr-db:/app/db \
         -v /path/to/download_folder:/app/temp_downloads \
         -v /path/to/root_folder:/content \
@@ -92,7 +92,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
     3. You can map multiple root folders by repeating `- /path/to/root_folder:/content` in the file, but then supplying different values for `/path/to/root_folder` and `/content`.
     4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
     5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes))
-    6. If you define a custom PUID and GUID here, they must have permission on any folder you've mapped in. The default user ID of '1000' is the first non-root user created on any Debian-based system, and generally exists on the host. If you are unsure of the _UID_ of the user you'd like the container to present as, see [Custom User](#custom-user).
+    6. If you define a custom PUID and PGID here, they must have permission on any folder you've mapped in. The default user ID of '1000' is the first non-root user created on any Debian-based system, and generally exists on the host. If you are unsure of the _UID_ of the user you'd like the container to present as, see [Custom User](#custom-user).
 
 ### Docker example
 
@@ -134,7 +134,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
     docker run -d \
         --name kapowarr \
         -e PUID:1000 \
-        -e GUID:1000 \
+        -e PGID:1000 \
         -v kapowarr-db:/app/db \
         -v /home/cas/media/Downloads:/app/temp_downloads \
         -v /home/cas/media/Comics:/RF \
@@ -184,7 +184,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
     - Create the stack with the named volume in it.
 
 Both of these options will create a named volume that you can then use in the examples above.  
-If you'd prefer to use a local folder on the host machine for storing config, Linux standards would suggest putting that in `/opt/application_name`, as the `/opt` directory is where program options should be stored. 
+If you'd prefer to use a local folder on the host machine for storing config, Linux standards would suggest putting that in `/opt/application_name`, as the `/opt` directory is where program options should be stored.  
 In this case, you'd create the desired folder with something like `mkdir /opt/kapowarr/db`, and replace 'kapowarr-db:/app/db' with '/opt/kapowarr/db:/app/db'.
 
 ### Custom User

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -52,7 +52,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
     docker run -d \
         --name kapowarr \
         -e PUID:1000 \
-        - GUID:1000 \
+        -e GUID:1000 \
         -v kapowarr-db:/app/db \
         -v /path/to/download_folder:/app/temp_downloads \
         -v /path/to/root_folder:/content \
@@ -108,6 +108,8 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
         mrcas/kapowarr:latest
     ```
 
+    In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.
+
 === "Docker Compose"
     ```yml
     version: '3.3'
@@ -124,7 +126,25 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
             image: 'mrcas/kapowarr:latest'
     ```
 
-In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.
+    In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.
+
+=== "Docker CLI (custom user)"
+    The command to get the docker container running can be found below:
+    ```bash
+    docker run -d \
+        --name kapowarr \
+        -e PUID:1000 \
+        -e GUID:1000 \
+        -v kapowarr-db:/app/db \
+        -v /home/cas/media/Downloads:/app/temp_downloads \
+        -v /home/cas/media/Comics:/RF \
+        -v /home/cas/media/Comics-2:/RF-2 \
+        -p 5656:5656
+        mrcas/kapowarr:latest
+    ```
+    
+    In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.  
+    We also have Kapowarr running with a user that has the user ID 1000 (the default non-root user for a linux server). If you have a user that has less permission than root that you'd like Kapowarr to run as, you'd define their user ID and group ID here.
 
 === "Docker Compose (custom user)"
     ```yml
@@ -145,8 +165,8 @@ In this example, we set `/home/cas/media/Downloads` as the download folder and w
             image: 'mrcas/kapowarr:latest'
     ```
 
-In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.  
-We also have Kapowarr running with a user that has the user ID 1000 (the default non-root user for a linux server). If you have a user that has less permission than root that you'd like Kapowarr to run as, you'd define their user ID and group ID here.
+    In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.  
+    We also have Kapowarr running with a user that has the user ID 1000 (the default non-root user for a linux server). If you have a user that has less permission than root that you'd like Kapowarr to run as, you'd define their user ID and group ID here.
 
 ### Named volumes
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -46,6 +46,27 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
     4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
     5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes))
 
+=== "Docker CLI (custom user)"
+    The command to get the docker container running can be found below:
+    ```bash
+    docker run -d \
+        --name kapowarr \
+        -e PUID:1000 \
+        - GUID:1000 \
+        -v kapowarr-db:/app/db \
+        -v /path/to/download_folder:/app/temp_downloads \
+        -v /path/to/root_folder:/content \
+        -p 5656:5656
+        mrcas/kapowarr:latest
+    ```
+    A few notes about this command:
+
+    1. Replace `/path/to/download_folder` with the path to your desired download folder. Everything is downloaded to this folder and when completed, moved out of to their final destination. It's smart to set this on a disk that can sustain more writes than normal. Ideally something like a _non_-network mounted ssd.
+    2. Replace `/path/to/root_folder` with the path to your desired root folder. Then, this folder will get mapped to `/content` inside the docker container. When adding a root folder in Kapowarr, you'll then set it's location as `/content`, mapping it this way to where ever `/path/to/root_folder` may be.
+    3. You can map multiple root folders by repeating `-v /path/to/root_folder:/content` in the command, but then supplying different values for `/path/to/root_folder` and `/content`.
+    4. Information on how to change the port can be found on the [Setup After Installation page](./setup_after_installation.md#port).
+    5. Using a named volume in docker requires you to create the volume before you can use it (refer to [Named Volumes](#named-volumes)).
+
 === "Docker Compose (custom user)"
     The contents of the docker-compose.yml file would look like this:
     ```yml

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -142,7 +142,7 @@ The recommended way to install Kapowarr is using Docker. After installing Kapowa
         -p 5656:5656
         mrcas/kapowarr:latest
     ```
-    
+
     In this example, we set `/home/cas/media/Downloads` as the download folder and we map the folder `/home/cas/media/Comics` to `/RF` and `/home/cas/media/Comics-2` to `/RF-2`. In Kapowarr, you'd then add `/RF` and `/RF-2` as root folders.  
     We also have Kapowarr running with a user that has the user ID 1000 (the default non-root user for a linux server). If you have a user that has less permission than root that you'd like Kapowarr to run as, you'd define their user ID and group ID here.
 
@@ -194,22 +194,21 @@ For a custom _group_, the same applies, but the group ID instead.
 
 === "Ubuntu"
     User ID: `id -u <username>`  
-    Replace '<username>' with the actual username you'd like it to run as.  
+    Replace `<username>` with the actual username you'd like it to run as.  
     Group ID: `id -g <username>`  
-    Replace '<username>' with the actual username you'd like to find the group of.
+    Replace `<username>` with the actual username you'd like to find the group of.
 
 === "Debian"
     User ID: `id -u <username>`  
-    Replace '<username>' with the actual username you'd like it to run as.  
+    Replace `<username>` with the actual username you'd like it to run as.  
     Group ID: `id -g <username>`  
-    Replace '<username>' with the actual username you'd like to find the group of.
+    Replace `<username>` with the actual username you'd like to find the group of.
 
 === "TrueNAS"
     User ID: In the web UI, go to Credentials -> Local Users.  
-    Find the relevant username you'd like to use, and look at the 'UID' column to find the UID.
+    - Find the relevant username you'd like to use, and look at the 'UID' column to find the UID.  
     Group ID: In the web UI, go to Credentials -> Local Groups.  
-    Find the relevant group you'd like to use, and look at the 'GID' column to find the GID.
-
+    - Find the relevant group you'd like to use, and look at the 'GID' column to find the GID.
 
 ## Manual Install
 

--- a/docs/setup_after_installation.md
+++ b/docs/setup_after_installation.md
@@ -54,7 +54,8 @@ Kapowarr has the ability to download from services like MediaFire and Mega. Thes
 
 ## Building up a library
 
-Now you're ready to build a library. At Volumes -> Add Volume, you can search for volumes and add them to your library.  
+Now you're ready to build a library.  
+At Volumes -> Add Volume, you can search for volumes and add them to your library.  
 Once you add one, a folder is automatically created for the volume in the root folder selected (see Settings -> Media Management -> File Naming -> Volume Folder Naming).  
 Then you can start downloading content for the volume, and all files will be put in this volume folder.  
 The naming of the files follows the format set in the settings (see Settings -> Media Management -> File Naming).

--- a/docs/setup_after_installation.md
+++ b/docs/setup_after_installation.md
@@ -50,7 +50,7 @@ Kapowarr has the ability to download directly from servers, but also to download
 
 ### Credentials
 
-Kapowarr has the ability to download from services like MediaFire and Mega. These services apply limits to how much you can download per day, or a download speed limit. An (paid) account for one of these services often offers higher limits. Kapowarr can take advantage of these extra features that these accounts offer. Under the credentials section, you can add credentials of accounts, which Kapowarr will use when downloading, taking advantage of the extra features. 
+Kapowarr has the ability to download from services like MediaFire and Mega. These services apply limits to how much you can download per day, or a download speed limit. An (paid) account for one of these services often offers higher limits. Kapowarr can take advantage of these extra features that these accounts offer. Under the credentials section, you can add credentials of accounts, which Kapowarr will use when downloading, taking advantage of the extra features.
 
 ## Building up a library
 

--- a/docs/setup_after_installation.md
+++ b/docs/setup_after_installation.md
@@ -56,11 +56,10 @@ Kapowarr has the ability to download from services like MediaFire and Mega. Thes
 
 Now you're ready to build a library. At Volumes -> Add Volume, you can search for volumes and add them to your library. Once you add one, a folder is automatically created for the volume in the root folder selected (see Settings -> Media Management -> File Naming -> Volume Folder Naming). Then you can start downloading content for the volume, and all files will be put in this volume folder. The naming of the files follows the format set in the settings (see Settings -> Media Management -> File Naming).
 
-### Unzipping
+## Importing a library
 
-Kapowarr has unzipping built-in. This means that it can extract zip files, filter the content to find the files that are actually desired, delete the other files, move the files to the correct location and name them correctly, delete the zip folder and delete the zip file. This can be done automatically for all downloaded zip files by enabling Settings -> Media Management -> Unzipping -> Unzip downloads. Unzipping can also be done for all zip files of a volume by pressing the "Unzip" button when viewing a volume.
-
-Importing an already existing library into Kapowarr is currently not very fluid (the "Library Import" feature found in Radarr/Sonarr is not yet implemented in Kapowarr). The advised way to get Kapowarr working with your current library:
+Importing an already existing library into Kapowarr is currently not very fluid (the "Library Import" feature found in Radarr/Sonarr is not yet implemented in Kapowarr).  
+The currently advised way to get Kapowarr working with your current library:
 
 1. Add a volume in Kapowarr.
 2. Move the content for the volume from the current folder to the volume folder generated and created by Kapowarr.


### PR DESCRIPTION
To resolve #33 (and #35 as a side-effect).

System will generate a user with sudo permissions inside the container, but with whatever UID and GID you define as environment variables (docs modification to follow later). Default UID/GID inside the container is 1000 (with this modification).

Note that this change does not break existing deployments providing the UID has permission to the directories in place (UID 1000 is the first non-root user created on a debian-based system by default).