### PR TITLE
Update Dockerfile.amd64

### DIFF
--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -13,6 +13,11 @@ RUN useradd -m -N -u $PUID -g $PGID $USER && \
 echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers && \
 chmod 0440 /etc/sudoers && \
 chmod g+w /etc/passwd
+RUN mkdir /app && \
+mkdir /app/temp_downloads && \
+chmod g+w /app/temp_downloads && \
+mkdir /app/db && \
+chmod g+w /app/db
 
 USER $USER
 


### PR DESCRIPTION
Force permissions to allow write access to non-default directory in container (does not override mounted paths).

Will still need to automate the container build process across to dockerhub, for ease of use.