### PR TITLE
UID/GID support for container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN pip3 install -r requirements.txt
 
 COPY . .
 
+RUN chmod -R 755 /app
+
 EXPOSE 5656
 
 CMD [ "python3", "/app/Kapowarr.py" ]


### PR DESCRIPTION
fixes #144

I think this mostly has to do with how the image is built, I don't see a github actions that builds and publishes it, so I suspect its due to a different base OS that doesn't manage permissions the same way?

Do you want me to whip you up a github action that publishes the image? i can include arm and maybe even windows too.