### PR TITLE
Fixed clean_title value for naming

### DIFF
--- a/backend/naming.py
+++ b/backend/naming.py
@@ -141,9 +141,9 @@ def _get_formatting_data(
 
     # Build formatted data
     if volume_data.title.startswith('The '):
-        clean_title = volume_data.title + ', The'
+        clean_title = volume_data.title.removeprefix('The ') + ', The'
     elif volume_data.title.startswith('A '):
-        clean_title = volume_data.title + ', A'
+        clean_title = volume_data.title.removeprefix('A ') + ', A'
     else:
         clean_title = volume_data.title or 'Unknown'
 

--- a/backend/naming.py
+++ b/backend/naming.py
@@ -141,9 +141,9 @@ def _get_formatting_data(
 
     # Build formatted data
     if volume_data.title.startswith('The '):
-        clean_title = volume_data.title.removeprefix('The ') + ', The'
+        clean_title = volume_data.title[len('The '):] + ', The'
     elif volume_data.title.startswith('A '):
-        clean_title = volume_data.title.removeprefix('A ') + ', A'
+        clean_title = volume_data.title[len('A '):] + ', A'
     else:
         clean_title = volume_data.title or 'Unknown'
 


### PR DESCRIPTION
Fix bug where a series titled: "A Series" would be retitled: "A Series, A". Now retitles correctly to "Series, A"