### PR TITLE
"Fix" naming bug with volume_as_empty

### DIFF
--- a/backend/naming.py
+++ b/backend/naming.py
@@ -305,7 +305,7 @@ def generate_issue_range_name(
     if (formatting_data['issue_title'] == 'Unknown'
         or (
             settings['volume_as_empty']
-            and formatting_data['issue_title'].lower().startswith('volume ')
+            and formatting_data['issue_title'].lower().startswith(('volume ', 'vol. '))
     )):
         format: str = settings['file_naming_empty']
     else:
@@ -357,7 +357,7 @@ def generate_issue_name(
     if (formatting_data['issue_title'] == 'Unknown'
         or (
             settings['volume_as_empty']
-            and formatting_data['issue_title'].lower().startswith('volume ')
+            and formatting_data['issue_title'].lower().startswith(('volume ', 'vol. '))
     )):
         format: str = settings['file_naming_empty']
     else:


### PR DESCRIPTION
"Fix" a bug with the volume_as_empty naming schema, where volumes starting with 'Vol. ' were not included. Happens in a minority of comics, but I've noticed it with a couple of mangas like Berserk.