### PR TITLE
Add ComicVine link to the volume tags section

### DIFF
--- a/frontend/static/css/view_volume.css
+++ b/frontend/static/css/view_volume.css
@@ -77,7 +77,8 @@ This flows better for ARIA.
 	gap: clamp(.5rem, 1.8vw, 1rem);
 }
 
-#volume-tags > p {
+#volume-tags > p,
+#volume-tags > a {
 	padding: .3rem;
 	border-radius: 3px;
 	background-color: var(--accent-color);

--- a/frontend/static/js/view_volume.js
+++ b/frontend/static/js/view_volume.js
@@ -38,6 +38,13 @@ const ViewEls = {
 	issues_list: document.querySelector('#issues-list')
 };
 
+function convertTitleToSlug(str) {
+    return str
+      .toLowerCase()
+      .replace(/[\s:]+/g, '-')
+      .replace(/^-+|-+$/g, '');
+  }
+
 //
 // Filling data
 //
@@ -179,6 +186,13 @@ function fillPage(data, api_key) {
 	const total_size = document.createElement('p');
 	total_size.innerText = data.total_size > 0 ? convertSize(data.total_size) : '0MB';
 	tags.appendChild(total_size);
+    
+	// ComicVine Link
+	const cvLink = document.createElement('a')
+	cvLink.innerText = 'ComicVine'
+	cvLink.href = `https://comicvine.gamespot.com/${convertTitleToSlug(data.title)}/4050-${data.comicvine_id}/`
+	cvLink.target = '_blank'
+	tags.appendChild(cvLink)
 
 	// Path
 	const path = ViewEls.vol_data.path;


### PR DESCRIPTION
Testing the waters a little bit. I'm more of a React frontend dev so I've been playing around with your setup. I link being able to go to ComicVine to view the linked volume so I added a link there just inside of the tags section.
![CleanShot 2024-10-16 at 22 58 02@2x](https://github.com/user-attachments/assets/543d802c-8b7b-4370-932b-462002f72446)
