### PR TITLE
Give all container users ability to read and execute /app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN pip3 install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+RUN chmod a+rx -R /app
+
 EXPOSE 5656
 
 CMD [ "python3", "/app/Kapowarr.py" ]


### PR DESCRIPTION
So if you do `docker run -it --rm -u 1026:100 mrcas/kapowarr:v1.2.0` then it can still run instead of permission denied