### PR TITLE
Fix publisher name in file path is not cleaned

### DIFF
--- a/backend/implementations/naming.py
+++ b/backend/implementations/naming.py
@@ -127,7 +127,7 @@ def _get_volume_naming_keys(
         volume_number=str(volume_data.volume_number).zfill(volume_padding),
         comicvine_id=volume_data.comicvine_id,
         year=volume_data.year,
-        publisher=volume_data.publisher,
+        publisher=clean_filestring(volume_data.publisher),
         special_version=sv_mapping.get(volume_data.special_version)
     )
 


### PR DESCRIPTION
Small fix that prevents publishers with a '/' in the name to create multiple nested directories.
Example:
Publisher Name: Marvel UK/Panini UK
Before: Marvel UK/Panini UK/VolumeName
After: Marvel UK-Panini UK/VolumeName