### PR TITLE
Added volumes in search result should be links

### DIFF
--- a/frontend/static/css/add_volume.css
+++ b/frontend/static/css/add_volume.css
@@ -113,15 +113,24 @@ main > div {
 
 	padding: 1.3rem;
 	border-radius: 2px;
-	background-color: var(--foreground-color);
 	color: var(--text-color);
 
 	text-align: left;
 
-	transition: background-color 200ms linear;
+	position: relative;
 }
 
-.search-entry:hover {
+.search-entry .viewvolume-link, .search-entry .addvolume-button {
+	background-color: var(--foreground-color);
+	transition: background-color 200ms linear;
+	position: absolute;
+	top: 0;
+	left: 0;
+	width: 100%;
+	height: 100%;
+}
+
+.search-entry .viewvolume-link:hover, .search-entry .addvolume-button:hover {
 	background-color: var(--hover-color);
 	text-decoration: none;
 	cursor: pointer;
@@ -132,6 +141,13 @@ main > div {
 	display: flex;
 	align-items: flex-start;
 	gap: 1rem;
+
+	position: relative;
+	pointer-events: none;
+}
+
+.search-entry a {
+	pointer-events: all;
 }
 
 .cover-info-container > :first-child {

--- a/frontend/static/css/add_volume.css
+++ b/frontend/static/css/add_volume.css
@@ -123,6 +123,8 @@ main > div {
 
 .search-entry:hover {
 	background-color: var(--hover-color);
+	text-decoration: none;
+	cursor: pointer;
 }
 
 .cover-info-container {

--- a/frontend/static/js/add_volume.js
+++ b/frontend/static/js/add_volume.js
@@ -42,8 +42,11 @@ const SearchEls = {
 // Searching
 //
 function addAlreadyAdded(entry, id) {
-	entry.onclick = undefined;
-	entry.href = `${url_base}/volumes/${id}`;
+	const buttonElement = entry.querySelector('button');
+	const anchorElement = document.createElement("a");
+	anchorElement.setAttribute("href", `${url_base}/volumes/${id}`);
+	anchorElement.setAttribute("class", `viewvolume-link`);
+	buttonElement.replaceWith(anchorElement);
 
 	const title = entry.querySelector('h2');
 	const aa_icon = document.createElement('img');
@@ -74,7 +77,7 @@ function buildResults(results, api_key) {
 
 		// Only allow adding volume if it isn't already added
 		if (result.already_added === null)
-			entry.onclick = e => showAddWindow(result.comicvine_id, api_key);
+			entry.querySelector('.addvolume-button').onclick = e => showAddWindow(result.comicvine_id, api_key);
 
 		entry.querySelector('img').src = result.cover_link;
 

--- a/frontend/static/js/add_volume.js
+++ b/frontend/static/js/add_volume.js
@@ -42,7 +42,8 @@ const SearchEls = {
 // Searching
 //
 function addAlreadyAdded(entry, id) {
-	entry.onclick = e => window.location.href = `${url_base}/volumes/${id}`;
+	entry.onclick = undefined;
+	entry.href = `${url_base}/volumes/${id}`;
 
 	const title = entry.querySelector('h2');
 	const aa_icon = document.createElement('img');
@@ -53,7 +54,7 @@ function addAlreadyAdded(entry, id) {
 
 function buildResults(results, api_key) {
 	SearchEls.search_results
-        .querySelectorAll('button:not(.filter-bar)')
+        .querySelectorAll('.search-entry:not(.filter-bar)')
         .forEach(e => e.remove());
 	results.forEach(result => {
 		const entry = SearchEls.pre_build.search_entry.cloneNode(true);
@@ -229,7 +230,7 @@ function search(reset_url_params=true) {
 
 			buildResults(json.result, api_key);
 
-			if (!SearchEls.search_results.querySelector('button:not(.filter-bar)'))
+			if (!SearchEls.search_results.querySelector('.search-entry:not(.filter-bar)'))
 				hide([SearchEls.msgs.loading], [SearchEls.msgs.empty]);
 			else
 				hide([SearchEls.msgs.loading], [SearchEls.search_results]);
@@ -252,7 +253,7 @@ function clearSearch(e) {
 		SearchEls.msgs.explain
 	]);
 	SearchEls.search_results
-        .querySelectorAll('button:not(.filter-bar)')
+        .querySelectorAll('.search-entry:not(.filter-bar)')
         .forEach(e => e.remove());
 	SearchEls.search_bar.input.value = '';
     setURLParams();
@@ -287,11 +288,11 @@ function applyFilters() {
 		filter += `[data-_publisher="${publisher}"]`;
 
 	if (filter === '')
-		hide([], SearchEls.search_results.querySelectorAll('button'));
+		hide([], SearchEls.search_results.querySelectorAll('.search-entry'));
 	else
 		hide(
-			SearchEls.search_results.querySelectorAll('button'),
-			SearchEls.search_results.querySelectorAll(`button${filter}`)
+			SearchEls.search_results.querySelectorAll('.search-entry'),
+			SearchEls.search_results.querySelectorAll(`.search-entry${filter}`)
 		);
 
     setURLParams();
@@ -377,7 +378,7 @@ function fillRootFolderInput(api_key) {
 
 function showAddWindow(comicvine_id, api_key) {
 	const volume_data = document.querySelector(
-		`button[data-comicvine_id="${comicvine_id}"]`
+		`.search-entry[data-comicvine_id="${comicvine_id}"]`
 	).dataset;
 	const body = {
 		'comicvine_id': volume_data.comicvine_id,
@@ -425,7 +426,7 @@ function addVolume() {
 	if (
 		volume_folder !== ''
 		&& volume_folder !== document.querySelector(
-			`button[data-comicvine_id="${data.comicvine_id}"]`
+			`.search-entry[data-comicvine_id="${data.comicvine_id}"]`
 		).dataset._volume_folder
 	) {
 		// Custom volume folder
@@ -444,7 +445,7 @@ function addVolume() {
 		.then(response => response.json())
 		.then(json => {
 			const entry = document.querySelector(
-				`button[data-comicvine_id="${data.comicvine_id}"]`
+				`.search-entry[data-comicvine_id="${data.comicvine_id}"]`
 			);
 			addAlreadyAdded(entry, json.result.id);
 			closeWindow();

--- a/frontend/templates/add_volume.html
+++ b/frontend/templates/add_volume.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block pre_build_els %}
-<button
+<a
 	class="search-entry"
 	data-title=""
 	data-cover=""
@@ -34,7 +34,7 @@
 		</div>
 	</div>
 	<div class="entry-spare-description description" aria-hidden="true"></div>
-</button>
+</a>
 {% endblock pre_build_els %}
 
 {% block windows %}

--- a/frontend/templates/add_volume.html
+++ b/frontend/templates/add_volume.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block pre_build_els %}
-<a
+<div
 	class="search-entry"
 	data-title=""
 	data-cover=""
@@ -22,6 +22,7 @@
 	data-_volume_number=""
 	data-_publisher=""
 >
+	<button class="addvolume-button"></button>
 	<div class="cover-info-container">
 		<div>
 			<img src="" alt="" loading="lazy">
@@ -34,7 +35,7 @@
 		</div>
 	</div>
 	<div class="entry-spare-description description" aria-hidden="true"></div>
-</a>
+</div>
 {% endblock pre_build_els %}
 
 {% block windows %}


### PR DESCRIPTION
When adding multiple volumes at the same time, it is handy to open the added volume in a new tab, so you can view it but also continue adding volumes. By correctly using the href property instead of onclick this works automatically.