### PR TITLE
Fix scanning volumes with numbers in name

### DIFF
--- a/backend/base/file_extraction.py
+++ b/backend/base/file_extraction.py
@@ -7,7 +7,7 @@ The string can be a filepath, filename or search result title, etc.
 
 from os.path import basename, dirname, splitext
 from re import IGNORECASE, Pattern, compile
-from typing import Collection, Dict, Tuple, Union
+from typing import Collection, Dict, Tuple, Union, Optional
 
 from backend.base.definitions import (CONTENT_EXTENSIONS, CharConstants,
                                       FileConstants, FilenameData,
@@ -16,6 +16,8 @@ from backend.base.helpers import (check_overlapping_pos,
                                   fix_year as fix_broken_year,
                                   normalise_number, normalise_string)
 from backend.base.logging import LOGGER
+from backend.base.files import (clean_filestring_simple, clean_filestring_smartly)
+
 
 # autopep8: off
 alphabet = {
@@ -250,7 +252,8 @@ def extract_filename_data(
     filepath: str,
     assume_volume_number: bool = True,
     prefer_folder_year: bool = False,
-    fix_year: bool = False
+    fix_year: bool = False,
+    assume_title: Optional[str] = None
 ) -> FilenameData:
     """Extract comic data from a string and generalise it. The string can be a
     filepath, filename or search result title, etc.
@@ -292,6 +295,11 @@ def extract_filename_data(
     series, year, volume_number, special_version, issue_number = (
         None, None, None, None, None
     )
+
+    # Remove title from filepath if present, makes sure we don't get issueNumber from volume title
+    if assume_title:
+        filepath = filepath.replace(clean_filestring_smartly(assume_title), "")
+        filepath = filepath.replace(clean_filestring_simple(assume_title), "")
 
     # Process folder if file is metadata file, as metadata filename contains
     # no useful information.
@@ -499,8 +507,11 @@ def extract_filename_data(
     if fix_year and year is not None:
         year = fix_broken_year(year)
 
+    if assume_title:
+        series = clean_filestring_simple(assume_title)
+
     file_data = FilenameData({
-        'series': series,
+        'series': assume_title or series,
         'year': year,
         'volume_number': volume_number,
         'special_version': special_version,

--- a/backend/implementations/volumes.py
+++ b/backend/implementations/volumes.py
@@ -1321,7 +1321,9 @@ def scan_files(
         ext=SCANNABLE_EXTENSIONS
     )
     for file in filtered_iter(folder_contents, set(filepath_filter)):
-        file_data = extract_filename_data(file)
+        file_data = extract_filename_data(file, assume_title=volume_data.title)
+
+        print(file_data)
 
         # Check if file matches volume
         if not file_importing_filter(

--- a/tests/Tbackend/file_extraction.py
+++ b/tests/Tbackend/file_extraction.py
@@ -26,6 +26,17 @@ class extract_filename_data(unittest.TestCase):
             )
         return
 
+    def run_cases_with_title(self, cases: Dict[str, tuple[dict, str]]):
+        self.longMessage = False
+        for input_str, (expected_output, title) in cases.items():
+            result = ef(input_str, assume_title=title)
+            self.assertEqual(
+                result,
+                expected_output,
+                f"The input '{input_str}' with title '{title}' isn't extracted properly:\n"
+                f"Output: {dumps(result, indent=4)}\nExpected: {dumps(expected_output, indent=4)}"
+            )
+
     # autopep8: off
     def test_general(self):
         cases = {
@@ -309,4 +320,22 @@ class extract_filename_data(unittest.TestCase):
                 {'series': 'Iron Man', 'year': 2012, 'volume_number': 2, 'special_version': 'metadata', 'issue_number': 5.0, 'annual': False}
         }
         self.run_cases(cases)
+
+    def test_number_in_title(self):
+        cases = {
+            'Deadpool Max 2 (2012) 003.cbz': (
+                {'series': 'Deadpool Max 2', 'year': 2012, 'volume_number': 1, 'special_version': None, 'issue_number': 3.0, 'annual': False},
+                "Deadpool Max 2"
+            ),
+            'Generation XGen 13 (2 covers) (1997).cbz': (
+                {'series': 'Generation XGen 13', 'year': 1997, 'volume_number': 1, 'special_version': 'tpb', 'issue_number': None, 'annual': False},
+                "Generation X/Gen 13"
+            ),
+            'Generation XGen 13 (1997)/series.json': (
+                {'series': 'Generation XGen 13', 'year': 1997, 'volume_number': 1, 'special_version': 'metadata', 'issue_number': None, 'annual': False},
+                "Generation X/Gen 13"
+            ),
+        }
+        self.run_cases_with_title(cases)
+
     # autopep8: on


### PR DESCRIPTION
This fixes some issues i was running into with volumes with numbers in the name:
- volumes would prefer the number found in the volume name over the actual issue number causing in wrong matches or no matches
e.g. Deadpool Max 2 (2012) 003.cbz will match issue 2 instead of 3
e.g. Generation X Gen 13 (2 covers) (1997).cbz won't be found
- series.json would not be detected as metadata and thus would be renamed using the number in the volume name as issue number AND it would be handled as issue and thus falsely match.
e.g. 44 Years of the Fantastic Four with a series.json, will mark the issue as downloaded and rename series.json on rename

This only works if the name matches exactly after cleaning. Theoretically this could be improved by only removing the number found in the title, but that seems more tricky.

I confirmed this working with manual scan, manual search and library import.