### PR TITLE
Rebase docker image to Linuxserver.io alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,20 @@ RUN \
     python3 \
     py3-pip \
     git \
+    gcompat \
     && pip3 install --break-system-packages --no-cache-dir --upgrade pip
 
 # Set working directory
 WORKDIR /app
 
-# Clone Kapowarr repository
-ARG KAPOWARR_REPO="https://github.com/Casvt/Kapowarr.git"
-ARG KAPOWARR_BRANCH="main"
+# Clone Kapowarr repository for remote build
+#ARG KAPOWARR_REPO="https://github.com/Casvt/Kapowarr.git"
+#ARG KAPOWARR_BRANCH="main"
+#RUN git clone --depth 1 --branch "${KAPOWARR_BRANCH}" "${KAPOWARR_REPO}" .
 
-RUN git clone --depth 1 --branch "${KAPOWARR_BRANCH}" "${KAPOWARR_REPO}" .
+# Clone local files for local build
+COPY requirements.txt requirements.txt
+COPY . .
 
 # Install Python dependencies
 RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 # Use linuxserver's base image (alpine + s6 overlay)  
 FROM lsiobase/alpine:3.22
+STOPSIGNAL SIGTERM
 
 # Metadata / labels (optional)  
 LABEL maintainer="you@example.com"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,46 @@
-# syntax=docker/dockerfile:1
+# Use linuxserver's base image (alpine + s6 overlay)  
+FROM lsiobase/alpine:3.22
 
-FROM python:3.8-slim-buster
-STOPSIGNAL SIGTERM
+# Metadata / labels (optional)  
+LABEL maintainer="you@example.com"
+ARG VERSION="latest"
 
+# Install build / runtime dependencies  
+RUN \
+  apk add --no-cache \
+    python3 \
+    py3-pip \
+    git \
+    && pip3 install --break-system-packages --no-cache-dir --upgrade pip
+
+# Set working directory
 WORKDIR /app
 
-COPY requirements.txt requirements.txt
-RUN pip3 install --no-cache-dir -r requirements.txt
+# Clone Kapowarr repository
+ARG KAPOWARR_REPO="https://github.com/Casvt/Kapowarr.git"
+ARG KAPOWARR_BRANCH="main"
 
-COPY . .
+RUN git clone --depth 1 --branch "${KAPOWARR_BRANCH}" "${KAPOWARR_REPO}" .
 
+# Install Python dependencies
+RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt
+
+# Ensure proper permissions for the abc user (linuxserver standard)
+RUN \
+  chown -R abc:abc /app \
+  && chmod -R 755 /app
+
+# Expose the web port (Kapowarr default is 5656)  
 EXPOSE 5656
 
-CMD [ "python3", "/app/Kapowarr.py" ]
+# Environment variables (PUID / PGID pattern used by linuxserver)  
+ENV PUID=1000 \
+    PGID=1000 \
+    TZ=UTC
+
+# Switch to non-root user (lsio pattern)
+# (the baseimage-alpine provides an 'abc' user/group)
+USER abc
+
+# Entry point / command
+CMD ["python3", "Kapowarr.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,14 @@ services:
   kapowarr:
     container_name: kapowarr
     image: mrcas/kapowarr:latest
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - TZ=Etc/UTC 
     volumes:
-      - "kapowarr-db:/app/db"
+      - "/path/to/config:/app/db"
       - "/path/to/download_folder:/app/temp_downloads"
-      - "/path/to/root_folder:/comics-1"
+      - "/path/to/comics:/comics"
     ports:
       - 5656:5656
 
-volumes:
-  kapowarr-db:

--- a/dockerfile.debian
+++ b/dockerfile.debian
@@ -1,5 +1,6 @@
 # Use linuxserver's Debian base image
 FROM lsiobase/debian:bookworm
+STOPSIGNAL SIGTERM
 
 # Metadata / labels (optional)  
 LABEL maintainer="you@example.com"

--- a/dockerfile.debian
+++ b/dockerfile.debian
@@ -1,0 +1,54 @@
+# Use linuxserver's Debian base image
+FROM lsiobase/debian:bookworm
+
+# Metadata / labels (optional)  
+LABEL maintainer="you@example.com"
+ARG VERSION="latest"
+
+# Install build / runtime dependencies  
+RUN \
+  apt-get update \
+  && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    git \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# Upgrade pip
+RUN pip3 install --no-cache-dir --upgrade pip --break-system-packages
+
+# Set working directory
+WORKDIR /app
+
+# Clone Kapowarr repository for remote build
+#ARG KAPOWARR_REPO="https://github.com/Casvt/Kapowarr.git"
+#ARG KAPOWARR_BRANCH="main"
+#RUN git clone --depth 1 --branch "${KAPOWARR_BRANCH}" "${KAPOWARR_REPO}" .
+
+# Clone local files for local build
+COPY requirements.txt requirements.txt
+COPY . .
+
+# Install Python dependencies
+RUN pip3 install --break-system-packages --no-cache-dir -r requirements.txt
+
+# Ensure proper permissions for the abc user (linuxserver standard)
+RUN \
+  chown -R abc:abc /app \
+  && chmod -R 755 /app
+
+# Expose the web port (Kapowarr default is 5656)  
+EXPOSE 5656
+
+# Environment variables (PUID / PGID pattern used by linuxserver)  
+ENV PUID=1000 \
+    PGID=1000 \
+    TZ=UTC
+
+# Switch to non-root user (lsio pattern)
+# (the lsiobase/debian provides an 'abc' user/group)
+USER abc
+
+# Entry point / command
+CMD ["python3", "Kapowarr.py"]


### PR DESCRIPTION
Like we discussed on Discord:
I created a new dockerfile and docker-compose file to rebase the docker image to the linuxserver.io base image. 
I choose alpine as a base image since it results in the smallest overall image. ombined with the fact that this base image is already on most machines (from other linuxserver.io images) resulting in a low overall consumption.

This image makes kapowarr run as a non root user. it either uses an internal user (called abc) or if given the user/group specified in PUID and PGID ENV variables. Also TZ Variable is honored.

I managed to only touch the dockerfile and docker-compose.yaml - no other changes to the code needed.  
The pull method slightly changed from path to git so it can be eaven build non locally using only the docker file. It can also be changed back to a local method - at the cost of being less flexible.
I also changed the external path variables in the compose.yaml to the linuxserver.io standards.


