### PR TITLE
Fix subprocess to use venv Python instead of system Python

### DIFF
--- a/Kapowarr.py
+++ b/Kapowarr.py
@@ -7,7 +7,7 @@ from multiprocessing import set_start_method
 from os import environ, name
 from signal import SIGINT, SIGTERM, signal
 from subprocess import Popen
-from sys import argv, executable
+from sys import argv
 from typing import NoReturn, Union
 
 from backend.base.custom_exceptions import InvalidKeyValue
@@ -170,15 +170,10 @@ def _run_sub_process(
         "KAPOWARR_START_TYPE": str(start_type.value)
     }
 
-    # Use sys.executable to ensure we use the same Python (venv) that started this script
-    # This fixes issue where get_python_exe() returns system Python instead of venv Python
-    py_exe = executable
+    py_exe = get_python_exe()
     if not py_exe:
-        # Fallback to get_python_exe() if sys.executable is not available
-        py_exe = get_python_exe()
-        if not py_exe:
-            print("ERROR: Python executable not found")
-            return 1
+        print("ERROR: Python executable not found")
+        return 1
 
     comm = [py_exe, "-u", __file__] + argv[1:]
     proc = Popen(

--- a/backend/base/helpers.py
+++ b/backend/base/helpers.py
@@ -112,8 +112,12 @@ def get_python_exe() -> Union[str, None]:
     Returns:
         Union[str, None]: The python executable path, or `None` if not found.
     """
-    if platform.startswith('darwin'):
-        filepath = None
+    # Always prefer sys.executable first, as it points to the actual Python
+    # that's running (including venv Python), ensuring subprocess uses same Python
+    filepath = executable or None
+    
+    # If sys.executable is not available or doesn't exist, fall back to bundle path on macOS
+    if (not filepath or not isfile(filepath)) and platform.startswith('darwin'):
         bundle_path = join(
             base_exec_prefix,
             "Resources",
@@ -126,8 +130,6 @@ def get_python_exe() -> Union[str, None]:
             from tempfile import mkdtemp
             filepath = join(mkdtemp(), "python")
             symlink(bundle_path, filepath)
-    else:
-        filepath = executable or None
 
     if filepath and not isfile(filepath):
         filepath = None


### PR DESCRIPTION
## Description

This PR fixes issue #288 where the subprocess spawned by `_run_sub_process()` uses the system Python instead of the venv's Python when running Kapowarr from a virtual environment.

## Changes

- Modified `get_python_exe()` in `backend/base/helpers.py` to prioritize `sys.executable` first
- This ensures the function returns the venv Python when running from a virtual environment
- Kept the original macOS bundle path logic as a fallback (preserves existing behavior for edge cases)
- `Kapowarr.py` continues to use `get_python_exe()` as originally intended

## Why This Fix Works

`sys.executable` always points to the Python interpreter that's currently running the script. By prioritizing it in `get_python_exe()`, if you run `venv/bin/python3 Kapowarr.py`, the function will return `venv/bin/python3`, ensuring the subprocess uses the same Python (and venv) as the parent process.

The fix respects the existing function design and maintains backward compatibility by keeping the macOS bundle path fallback logic.

## Testing

- ✅ Kapowarr starts successfully from a virtual environment
- ✅ No more `ModuleNotFoundError` for packages installed in the venv
- ✅ Server responds correctly (HTTP 200)
- ✅ Backward compatible (fallback logic preserved)

Fixes #288