### PR TITLE
Add issue sorting feature (sort by issue number or date)

### DIFF
--- a/backend/base/definitions.py
+++ b/backend/base/definitions.py
@@ -357,6 +357,15 @@ class LibrarySorting(BaseEnum):
                          "title, year, volume_number")
 
 
+class IssueSorting(BaseEnum):
+    """
+    The way to order issues within a volume
+    """
+
+    DATE = "date, calculated_issue_number"
+    ISSUE_NUMBER = "calculated_issue_number"
+
+
 class LibraryFilter(BaseEnum):
     """
     The filter to apply to the library, where the key value is the entire

--- a/backend/implementations/volumes.py
+++ b/backend/implementations/volumes.py
@@ -21,7 +21,7 @@ from backend.base.custom_exceptions import (InvalidKey, InvalidKeyValue,
                                             VolumeNotFound)
 from backend.base.definitions import (Constants, FileConstants, FileData,
                                       GeneralFileData, GeneralFileType,
-                                      IssueData, LibraryFilter,
+                                      IssueData, IssueSorting, LibraryFilter,
                                       LibrarySorting, MonitorScheme,
                                       SpecialVersion, VolumeData)
 from backend.base.file_extraction import extract_filename_data
@@ -283,8 +283,15 @@ class Volume:
             "special_version": SpecialVersion(data["special_version"])
         })
 
-    def get_public_keys(self) -> dict:
+    def get_public_keys(
+        self,
+        issue_sort: IssueSorting = IssueSorting.DATE
+    ) -> dict:
         """Get data about the volume for the public to see (the API).
+
+        Args:
+            issue_sort (IssueSorting, optional): How to sort the issues.
+                Defaults to IssueSorting.DATE.
 
         Returns:
             dict: The data.
@@ -335,7 +342,7 @@ class Volume:
             volume_info['root_folder_path']
         )
         del volume_info['root_folder_path']
-        volume_info['issues'] = [i.todict() for i in self.get_issues()]
+        volume_info['issues'] = [i.todict() for i in self.get_issues(sort=issue_sort)]
         volume_info['general_files'] = self.get_general_files()
 
         return volume_info
@@ -379,7 +386,8 @@ class Volume:
 
     def get_issues(
         self,
-        _skip_files: bool = False
+        _skip_files: bool = False,
+        sort: IssueSorting = IssueSorting.DATE
     ) -> List[IssueData]:
         """Get list of issues that are in the volume.
 
@@ -388,11 +396,14 @@ class Volume:
             each issue. Saves quite a bit of time.
                 Defaults to False.
 
+            sort (IssueSorting, optional): How to sort the issues.
+                Defaults to IssueSorting.DATE.
+
         Returns:
             List[IssueData]: The list of issues.
         """
         cursor = get_db()
-        issues = cursor.execute("""
+        issues = cursor.execute(f"""
             SELECT
                 id, volume_id, comicvine_id,
                 issue_number, calculated_issue_number,
@@ -400,7 +411,7 @@ class Volume:
                 monitored
             FROM issues
             WHERE volume_id = ?
-            ORDER BY date, calculated_issue_number
+            ORDER BY {sort.value}
             """,
             (self.id,)
         ).fetchalldict()

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -11,10 +11,10 @@ from backend.base.custom_exceptions import (InvalidKeyValue,
                                             KeyNotFound, TaskNotFound)
 from backend.base.definitions import (BlocklistReason, BlocklistReasonID,
                                       CredentialData, CredentialSource,
-                                      DownloadSource, KapowarrException,
-                                      LibraryFilter, LibrarySorting,
-                                      MonitorScheme, SpecialVersion,
-                                      StartType, VolumeData)
+                                      DownloadSource, IssueSorting,
+                                      KapowarrException, LibraryFilter,
+                                      LibrarySorting, MonitorScheme,
+                                      SpecialVersion, StartType, VolumeData)
 from backend.base.helpers import hash_password
 from backend.base.logging import LOGGER, get_log_file_contents
 from backend.features.download_queue import (DownloadHandler,
@@ -117,6 +117,12 @@ def extract_key(request, key: str, check_existence: bool = True) -> Any:
         elif key == 'sort':
             try:
                 value = LibrarySorting[value.upper()]
+            except KeyError:
+                raise InvalidKeyValue(key, value)
+
+        elif key == 'issue_sort':
+            try:
+                value = IssueSorting[value.upper()]
             except KeyError:
                 raise InvalidKeyValue(key, value)
 
@@ -804,7 +810,10 @@ def api_volume(id: int):
     volume = library.get_volume(id)
 
     if request.method == 'GET':
-        volume_info = volume.get_public_keys()
+        issue_sort = extract_key(request, 'issue_sort', False)
+        if issue_sort is None:
+            issue_sort = IssueSorting.DATE
+        volume_info = volume.get_public_keys(issue_sort=issue_sort)
         return return_api(volume_info)
 
     elif request.method == 'PUT':

--- a/frontend/static/css/view_volume.css
+++ b/frontend/static/css/view_volume.css
@@ -135,6 +135,31 @@ This flows better for ARIA.
 .issue-date {
 	width: 6.5rem;
 }
+
+.issue-number.sort-active,
+.issue-date.sort-active {
+	position: relative;
+	color: var(--text-color);
+}
+
+.issue-number.sort-active.sort-asc::after,
+.issue-date.sort-active.sort-asc::after {
+	content: ' ▲';
+	font-size: 0.7em;
+	opacity: 0.8;
+}
+
+.issue-number.sort-active.sort-desc::after,
+.issue-date.sort-active.sort-desc::after {
+	content: ' ▼';
+	font-size: 0.7em;
+	opacity: 0.8;
+}
+
+.issue-number:hover,
+.issue-date:hover {
+	opacity: 0.8;
+}
 .issue-status {
 	width: 3rem;
 }

--- a/frontend/static/js/view_volume.js
+++ b/frontend/static/js/view_volume.js
@@ -41,6 +41,9 @@ const ViewEls = {
 	issues_list: document.querySelector('#issues-list')
 };
 
+let currentIssueSort = 'DATE'; // 'DATE' or 'ISSUE_NUMBER'
+let currentSortDirection = 'asc'; // 'asc' or 'desc'
+
 //
 // Filling data
 //
@@ -105,11 +108,90 @@ class IssueEntry {
 	};
 };
 
+function loadVolume(volume_id, api_key, sortOverride = null, directionOverride = null) {
+	// Use provided sort override, or load from localStorage, or use default
+	let sortToUse = sortOverride;
+	let directionToUse = directionOverride;
+	
+	if (!sortToUse) {
+		const savedSort = localStorage.getItem('issueSort');
+		if (savedSort === 'ISSUE_NUMBER' || savedSort === 'DATE') {
+			sortToUse = savedSort;
+		} else {
+			sortToUse = 'DATE';
+		}
+	}
+	
+	if (!directionToUse) {
+		const savedDirection = localStorage.getItem('issueSortDirection');
+		if (savedDirection === 'asc' || savedDirection === 'desc') {
+			directionToUse = savedDirection;
+		} else {
+			directionToUse = 'asc';
+		}
+	}
+	
+	currentIssueSort = sortToUse;
+	currentSortDirection = directionToUse;
+	
+	fetchAPI(`/volumes/${volume_id}`, api_key, {issue_sort: currentIssueSort})
+	.then(json => fillPage(json.result, api_key))
+	.catch(e => {
+		if (e.status === 404)
+			window.location.href = `${url_base}/`
+		else
+			console.log(e);
+	});
+}
+
+function updateSortIndicator() {
+	// Get headers dynamically in case DOM wasn't ready when script loaded
+	// Use 'thead th' to specifically target header cells, not body cells
+	const issue_number_header = document.querySelector('thead th.issue-number');
+	const issue_date_header = document.querySelector('thead th.issue-date');
+	
+	// Remove sort indicators from both headers
+	if (issue_number_header) {
+		issue_number_header.classList.remove('sort-active');
+		issue_number_header.classList.remove('sort-asc');
+		issue_number_header.classList.remove('sort-desc');
+	}
+	if (issue_date_header) {
+		issue_date_header.classList.remove('sort-active');
+		issue_date_header.classList.remove('sort-asc');
+		issue_date_header.classList.remove('sort-desc');
+	}
+	
+	// Add sort indicator to active header
+	const activeHeader = currentIssueSort === 'ISSUE_NUMBER' ? issue_number_header : issue_date_header;
+	if (activeHeader) {
+		activeHeader.classList.add('sort-active');
+		activeHeader.classList.add(currentSortDirection === 'asc' ? 'sort-asc' : 'sort-desc');
+	}
+}
+
+function setIssueSort(sort, api_key) {
+	// If clicking the same column, toggle direction; otherwise switch column and reset to asc
+	if (currentIssueSort === sort) {
+		currentSortDirection = currentSortDirection === 'asc' ? 'desc' : 'asc';
+	} else {
+		currentIssueSort = sort;
+		currentSortDirection = 'asc';
+	}
+	localStorage.setItem('issueSort', currentIssueSort);
+	localStorage.setItem('issueSortDirection', currentSortDirection);
+	updateSortIndicator();
+	loadVolume(volume_id, api_key, currentIssueSort, currentSortDirection); // Pass sort to avoid localStorage override
+}
+
 function fillTable(issues, api_key) {
 	ViewEls.issues_list.innerHTML = '';
 
-	for (i = issues.length - 1; i >= 0; i--) {
-		const obj = issues[i];
+	// Reverse the array if sorting descending, otherwise keep as-is (already sorted ascending)
+	const issuesToDisplay = currentSortDirection === 'desc' ? [...issues].reverse() : issues;
+
+	for (i = 0; i < issuesToDisplay.length; i++) {
+		const obj = issuesToDisplay[i];
 
 		const entry = ViewEls.pre_build.issue_entry.cloneNode(true);
 		entry.dataset.id = obj.id;
@@ -177,8 +259,9 @@ function fillPage(data, api_key) {
 	// Title
 	ViewEls.vol_data.title.innerText = data.title;
 
-	// Tags
+	// Tags - clear first to avoid duplication
 	const tags = ViewEls.vol_data.tags;
+	tags.innerHTML = ''; // Clear existing tags before adding new ones
 	if (data.year !== null) {
 		const year = document.createElement('p');
 		year.innerText = data.year;
@@ -212,6 +295,9 @@ function fillPage(data, api_key) {
 
 	// fill issue lists
 	fillTable(data.issues, api_key);
+	
+	// Update sort indicators
+	updateSortIndicator();
 
 	mapButtons(volume_id);
 
@@ -739,14 +825,32 @@ function showInfoWindow(window) {
 
 usingApiKey()
 .then(api_key => {
-	fetchAPI(`/volumes/${volume_id}`, api_key)
-	.then(json => fillPage(json.result, api_key))
-	.catch(e => {
-		if (e.status === 404)
-			window.location.href = `${url_base}/`
-		else
-			console.log(e);
-	});
+	// Load sort preference from localStorage or use default
+	const savedSort = localStorage.getItem('issueSort');
+	const savedDirection = localStorage.getItem('issueSortDirection');
+	if (savedSort === 'ISSUE_NUMBER' || savedSort === 'DATE') {
+		currentIssueSort = savedSort;
+	}
+	if (savedDirection === 'asc' || savedDirection === 'desc') {
+		currentSortDirection = savedDirection;
+	}
+	loadVolume(volume_id, api_key);
+
+	// Set up sortable headers (get them dynamically in case DOM wasn't ready)
+	// Use 'thead th' to specifically target header cells, not body cells
+	const issue_number_header = document.querySelector('thead th.issue-number');
+	const issue_date_header = document.querySelector('thead th.issue-date');
+	
+	if (issue_number_header) {
+		issue_number_header.style.cursor = 'pointer';
+		issue_number_header.title = 'Click to sort by issue number';
+		issue_number_header.onclick = e => setIssueSort('ISSUE_NUMBER', api_key);
+	}
+	if (issue_date_header) {
+		issue_date_header.style.cursor = 'pointer';
+		issue_date_header.title = 'Click to sort by release date';
+		issue_date_header.onclick = e => setIssueSort('DATE', api_key);
+	}
 
 	ViewEls.tool_bar.refresh.onclick = e => refreshVolume(api_key);
 	ViewEls.tool_bar.auto_search.onclick = e => autosearchVolume(api_key);


### PR DESCRIPTION
This PR implements issue #221, allowing users to sort issues within a volume by either issue number or release date.

## Changes
- Added `IssueSorting` enum with `DATE` and `ISSUE_NUMBER` options
- Updated `Volume.get_issues()` to accept sort parameter
- Updated `Volume.get_public_keys()` to accept and pass `issue_sort`
- Added `issue_sort` query parameter to `/volumes/<id>` API endpoint
- Added clickable sort headers (# and Release Date) in frontend
- Added visual indicators (▲/▼) for sort direction
- Support ascending/descending toggle by clicking same header
- Persist sort preference in localStorage
- Fixed tag duplication issue when reloading volume

## Testing
- Clicking "#" header sorts by issue number
- Clicking "Release Date" header sorts by date
- Clicking the same header again toggles ascending/descending
- Sort preference persists across page reloads
- Visual indicators show current sort column and direction

Fixes #221