### PR TITLE
Add unsaved changes tracking and warning for settings pages

### DIFF
--- a/frontend/static/css/settings.css
+++ b/frontend/static/css/settings.css
@@ -423,3 +423,16 @@
 #remote-mapping-list > tr > td {
 	border-top: 1px solid var(--border-color);
 }
+
+/*  */
+/* Unsaved changes indicator */
+/*  */
+#save-button.has-unsaved-changes {
+	background-color: var(--accent-color);
+	transition: background-color 200ms ease-in-out;
+}
+
+#save-button.has-unsaved-changes:hover {
+	background-color: var(--accent-color);
+	opacity: 0.9;
+}

--- a/frontend/static/js/settings_common.js
+++ b/frontend/static/js/settings_common.js
@@ -1,0 +1,92 @@
+// Common utilities for settings pages
+
+let hasUnsavedChanges = false;
+let initialValues = {};
+let userConfirmedLeave = false; // Flag to prevent double warnings
+
+/**
+ * Initialize unsaved changes tracking
+ * @param {Object} getCurrentValues - Function that returns current form values as an object
+ * 
+ * Note: getCurrentValues() should follow the same pattern as fillSettings() - 
+ * fields are used explicitly to match the API structure and handle type conversions.
+ * This ensures type safety and handles special cases (localStorage, transformations, arrays).
+ */
+function initUnsavedChangesTracking(getCurrentValues) {
+	// Store initial values
+	initialValues = JSON.parse(JSON.stringify(getCurrentValues()));
+	hasUnsavedChanges = false;
+	userConfirmedLeave = false; // Reset flag when initializing
+	updateSaveButtonState();
+	
+	// Add change listeners to all inputs, selects, and textareas
+	const inputs = document.querySelectorAll('#settings-form input, #settings-form select, #settings-form textarea');
+	inputs.forEach(input => {
+		// Skip if it's a button or submit input
+		if (input.type === 'button' || input.type === 'submit') return;
+		
+		input.addEventListener('change', () => checkForChanges(getCurrentValues));
+		input.addEventListener('input', () => checkForChanges(getCurrentValues));
+	});
+	
+	// Warn before leaving page (browser navigation: close tab, refresh, etc.)
+	window.addEventListener('beforeunload', (e) => {
+		if (hasUnsavedChanges && !userConfirmedLeave) {
+			e.preventDefault();
+			e.returnValue = ''; // Chrome requires returnValue to be set
+			return ''; // Some browsers require a return value
+		}
+	});
+	
+	// Intercept navigation links (in-app navigation)
+	document.querySelectorAll('nav a').forEach(link => {
+		link.addEventListener('click', (e) => {
+			if (hasUnsavedChanges) {
+				if (!confirm('You have unsaved changes. Are you sure you want to leave this page?')) {
+					e.preventDefault();
+					return false;
+				} else {
+					// User confirmed, set flag to prevent beforeunload from also showing
+					userConfirmedLeave = true;
+				}
+			}
+		});
+	});
+}
+
+/**
+ * Check if current values differ from initial values
+ */
+function checkForChanges(getCurrentValues) {
+	const currentValues = getCurrentValues();
+	const currentStr = JSON.stringify(currentValues);
+	const initialStr = JSON.stringify(initialValues);
+	
+	hasUnsavedChanges = currentStr !== initialStr;
+	updateSaveButtonState();
+}
+
+/**
+ * Update save button visual state based on unsaved changes
+ */
+function updateSaveButtonState() {
+	const saveButton = document.querySelector('#save-button');
+	if (!saveButton) return;
+	
+	if (hasUnsavedChanges) {
+		saveButton.classList.add('has-unsaved-changes');
+	} else {
+		saveButton.classList.remove('has-unsaved-changes');
+	}
+}
+
+/**
+ * Mark settings as saved (reset tracking)
+ * @param {Object} getCurrentValues - Function that returns current form values as an object
+ */
+function markAsSaved(getCurrentValues) {
+	initialValues = JSON.parse(JSON.stringify(getCurrentValues()));
+	hasUnsavedChanges = false;
+	updateSaveButtonState();
+}
+

--- a/frontend/static/js/settings_download.js
+++ b/frontend/static/js/settings_download.js
@@ -1,3 +1,14 @@
+function getCurrentValues() {
+	return {
+		download_folder: document.querySelector('#download-folder-input').value,
+		concurrent_direct_downloads: parseInt(document.querySelector('#concurrent-direct-downloads-input').value),
+		failing_download_timeout: parseInt(document.querySelector('#download-timeout-input').value || 0) * 60,
+		seeding_handling: document.querySelector('#seeding-handling-input').value,
+		delete_completed_downloads: document.querySelector('#delete-downloads-input').checked,
+		service_preference: [...document.querySelectorAll('#pref-table select')].map(e => e.value)
+	};
+}
+
 function fillSettings(api_key) {
 	fetchAPI('/settings', api_key)
 	.then(json => {
@@ -7,6 +18,9 @@ function fillSettings(api_key) {
 		document.querySelector('#seeding-handling-input').value = json.result.seeding_handling;
 		document.querySelector('#delete-downloads-input').checked = json.result.delete_completed_downloads;
 		fillPref(json.result.service_preference);
+		
+		// Initialize unsaved changes tracking after settings are loaded
+		initUnsavedChangesTracking(getCurrentValues);
 	});
 };
 
@@ -22,9 +36,10 @@ function saveSettings(api_key) {
 		'service_preference': [...document.querySelectorAll('#pref-table select')].map(e => e.value)
 	};
 	sendAPI('PUT', '/settings', api_key, {}, data)
-	.then(response => 
-		document.querySelector("#save-button p").innerText = 'Saved'
-	)
+	.then(response => {
+		document.querySelector("#save-button p").innerText = 'Saved';
+		markAsSaved(getCurrentValues);
+	})
 	.catch(e => {
 		document.querySelector("#save-button p").innerText = 'Failed';
         e.json().then(e => {
@@ -87,6 +102,8 @@ function updatePrefOrder(e) {
 			break;
 		};
 	};
+	// Service preference change triggers unsaved changes check
+	checkForChanges(getCurrentValues);
 };
 
 // code run on load

--- a/frontend/static/js/settings_general.js
+++ b/frontend/static/js/settings_general.js
@@ -1,3 +1,16 @@
+function getCurrentValues() {
+	return {
+		host: document.querySelector('#bind-address-input').value,
+		port: parseInt(document.querySelector('#port-input').value),
+		url_base: document.querySelector('#url-base-input').value,
+		auth_password: document.querySelector('#password-input').value,
+		comicvine_api_key: document.querySelector('#cv-input').value,
+		flaresolverr_base_url: document.querySelector('#flaresolverr-input').value,
+		log_level: parseInt(document.querySelector('#log-level-input').value),
+		theme: document.querySelector('#theme-input').value
+	};
+}
+
 function fillSettings(api_key) {
 	fetchAPI('/settings', api_key)
 	.then(json => {
@@ -11,6 +24,9 @@ function fillSettings(api_key) {
 		document.querySelector('#log-level-input').value = json.result.log_level;
 	});
 	document.querySelector('#theme-input').value = getLocalStorage('theme')['theme'];
+	
+	// Initialize unsaved changes tracking after all settings are loaded
+	setTimeout(() => initUnsavedChangesTracking(getCurrentValues), 100);
 };
 
 function saveSettings(api_key) {
@@ -31,6 +47,7 @@ function saveSettings(api_key) {
 	.then(json => {
 		if (json.error !== null) return Promise.reject(json);
 		document.querySelector("#save-button p").innerText = 'Saved';
+		markAsSaved(getCurrentValues);
 	})
 	.catch(e => {
 		document.querySelector("#save-button p").innerText = 'Failed';
@@ -75,4 +92,6 @@ document.querySelector('#theme-input').onchange = e => {
 		document.querySelector(':root').classList.add('dark-mode');
 	else if (value === 'light')
 		document.querySelector(':root').classList.remove('dark-mode');
+	// Theme change triggers unsaved changes check
+	checkForChanges(getCurrentValues);
 };

--- a/frontend/static/js/settings_mediamanagement.js
+++ b/frontend/static/js/settings_mediamanagement.js
@@ -19,6 +19,27 @@ const inputs = {
 //
 // Settings
 //
+function getCurrentValues() {
+	return {
+		rename_downloaded_files: inputs.renaming_input.checked,
+		replace_illegal_characters: inputs.replace_illegal_characters.checked,
+		volume_folder_naming: inputs.volume_folder_naming_input.value,
+		file_naming: inputs.file_naming_input.value,
+		file_naming_empty: inputs.file_naming_empty_input.value,
+		file_naming_special_version: inputs.file_naming_sv_input.value,
+		file_naming_vai: inputs.file_naming_vai_input.value,
+		long_special_version: inputs.long_sv_input.checked,
+		issue_padding: parseInt(inputs.issue_padding_input.value),
+		volume_padding: parseInt(inputs.volume_padding_input.value),
+		create_empty_volume_folders: inputs.create_empty_volume_folders_input.checked,
+		delete_empty_folders: inputs.delete_empty_folders_input.checked,
+		unmonitor_deleted_issues: inputs.unmonitor_deleted_input.checked,
+		convert: inputs.convert_input.checked,
+		extract_issue_ranges: inputs.extract_input.checked,
+		format_preference: convert_preference
+	};
+}
+
 function fillSettings(api_key) {
 	fetchAPI('/settings', api_key)
 	.then(json => {
@@ -39,6 +60,9 @@ function fillSettings(api_key) {
 		inputs.extract_input.checked = json.result.extract_issue_ranges;
 
 		fillConvert(api_key, json.result.format_preference);
+		
+		// Initialize unsaved changes tracking after settings are loaded
+		initUnsavedChangesTracking(getCurrentValues);
 	});
 };
 
@@ -68,9 +92,10 @@ function saveSettings(api_key) {
 		'format_preference': convert_preference,
 	};
 	sendAPI('PUT', '/settings', api_key, {}, data)
-	.then(response => 
-		document.querySelector("#save-button p").innerText = 'Saved'
-	)
+	.then(response => {
+		document.querySelector("#save-button p").innerText = 'Saved';
+		markAsSaved(getCurrentValues);
+	})
 	.catch(e => {
 		document.querySelector("#save-button p").innerText = 'Failed';
 		e.json().then(e => {
@@ -155,6 +180,8 @@ function updateConvertList() {
 			other_el.value = missing_value;
 
 			convert_preference = getConvertList();
+			// Convert preference change triggers unsaved changes check
+			checkForChanges(getCurrentValues);
 		};
 		select_container.appendChild(select);
 		entry.appendChild(select_container);
@@ -167,6 +194,8 @@ function updateConvertList() {
 			entry.remove();
 			convert_preference = getConvertList();
 			updateConvertList();
+			// Convert preference change triggers unsaved changes check
+			checkForChanges(getCurrentValues);
 		};
 		const delete_button_icon = document.createElement('img');
 		delete_button_icon.src = `${url_base}/static/img/delete.svg`;
@@ -358,5 +387,7 @@ document.querySelector('#add-convert-input').onchange = e => {
 	if (value !== 'No Conversion') {
 		convert_preference.push(value);
 		updateConvertList();
+		// Convert preference change triggers unsaved changes check
+		checkForChanges(getCurrentValues);
 	};
 };

--- a/frontend/static/js/settings_metadata.js
+++ b/frontend/static/js/settings_metadata.js
@@ -1,7 +1,16 @@
+function getCurrentValues() {
+	return {
+		date_type: document.querySelector('#date-type-input').value
+	};
+}
+
 function fillSettings(api_key) {
 	fetchAPI('/settings', api_key)
 	.then(json => {
 		document.querySelector('#date-type-input').value = json.result.date_type;
+		
+		// Initialize unsaved changes tracking after settings are loaded
+		initUnsavedChangesTracking(getCurrentValues);
 	});
 };
 
@@ -15,6 +24,7 @@ function saveSettings(api_key) {
 	.then(json => {
 		if (json.error !== null) return Promise.reject(json);
 		document.querySelector("#save-button p").innerText = 'Saved';
+		markAsSaved(getCurrentValues);
 	})
 	.catch(e => {
 		document.querySelector("#save-button p").innerText = 'Failed';

--- a/frontend/templates/settings_download.html
+++ b/frontend/templates/settings_download.html
@@ -5,6 +5,7 @@
 	<link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
 {% endblock %}
 {% block js %}
+	<script src="{{ url_for('static', filename='js/settings_common.js') }}" defer></script>
 	<script src="{{ url_for('static', filename='js/settings_download.js') }}" defer></script>
 {% endblock %}
 

--- a/frontend/templates/settings_general.html
+++ b/frontend/templates/settings_general.html
@@ -5,6 +5,7 @@
 	<link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
 {% endblock %}
 {% block js %}
+	<script src="{{ url_for('static', filename='js/settings_common.js') }}" defer></script>
 	<script src="{{ url_for('static', filename='js/settings_general.js') }}" defer></script>
 {% endblock %}
 

--- a/frontend/templates/settings_mediamanagement.html
+++ b/frontend/templates/settings_mediamanagement.html
@@ -5,6 +5,7 @@
 	<link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
 {% endblock %}
 {% block js %}
+	<script src="{{ url_for('static', filename='js/settings_common.js') }}" defer></script>
 	<script src="{{ url_for('static', filename='js/settings_mediamanagement.js') }}" defer></script>
 {% endblock %}
 

--- a/frontend/templates/settings_metadata.html
+++ b/frontend/templates/settings_metadata.html
@@ -5,6 +5,7 @@
 	<link rel="stylesheet" href="{{ url_for('static', filename='css/settings.css') }}">
 {% endblock %}
 {% block js %}
+	<script src="{{ url_for('static', filename='js/settings_common.js') }}" defer></script>
 	<script src="{{ url_for('static', filename='js/settings_metadata.js') }}" defer></script>
 {% endblock %}
 


### PR DESCRIPTION
This PR implements issue #152, adding visual feedback and warnings when users have unsaved changes on settings pages.

## Changes
- Created shared `settings_common.js` utility for tracking unsaved changes
- Save button changes color (to accent color) when there are unsaved changes
- Warn user with browser dialog when trying to leave page (close tab/refresh) with unsaved changes
- Warn user with confirmation dialog when clicking navigation links with unsaved changes
- Track changes for all input fields, selects, and checkboxes
- Reset tracking after successful save
- Fixed double popup issue by using `userConfirmedLeave` flag to prevent both warnings from showing

## Implementation Details
- `getCurrentValues()` follows the same pattern as `fillSettings()` - fields are used explicitly to match the API structure and handle type conversions (parseInt, transformations, arrays, localStorage)
- Works on all settings pages: General, Download, Metadata, Media Management
- Handles special cases like theme (localStorage), service preferences (arrays), and convert preferences (dynamic lists)

## Testing
- Make changes to any settings page
- Save button should turn yellow (accent color)
- Try to navigate away via link - should show confirmation dialog
- Try to close tab/refresh - should show browser warning
- Save changes - button should return to normal and warnings should not appear

Fixes #152

<img width="489" height="255" alt="image" src="https://github.com/user-attachments/assets/9c8898b3-4ede-46da-b321-0a1e03012735" />
<img width="485" height="259" alt="image" src="https://github.com/user-attachments/assets/7c631ae6-a95b-47e8-9407-9a76966ede90" />
<img width="467" height="181" alt="image" src="https://github.com/user-attachments/assets/6846d67e-4209-45fc-bca1-841d091ad064" />
