### PR TITLE
Add strftime date formatting support for issue_release_date variable

### DIFF
--- a/backend/base/definitions.py
+++ b/backend/base/definitions.py
@@ -675,7 +675,7 @@ class IssueNamingKeys(SVNamingKeys):
     issue_comicvine_id: int
     issue_number: Union[str, None]
     issue_title: Union[str, None]
-    issue_release_date: Union[str, None]
+    issue_release_date: Union['DateFormatter', str, None]  # Can be DateFormatter or str for compatibility
     issue_release_year: Union[int, None]
 
 

--- a/backend/implementations/naming.py
+++ b/backend/implementations/naming.py
@@ -6,6 +6,7 @@ The (re)naming of folders and media
 
 from __future__ import annotations
 
+from datetime import datetime
 from os.path import abspath, basename, isdir, isfile, join, splitext
 from re import compile
 from string import Formatter
@@ -39,6 +40,67 @@ from backend.internals.settings import Settings
 
 remove_year_in_image_regex = compile(r'(?:19|20)\d{2}')
 extra_spaces_regex = compile(r'(?<=\s)(\s+)')
+
+
+# =====================
+# region Date Formatting
+# =====================
+
+class DateFormatter:
+    """Wrapper for date strings that supports strftime formatting.
+    
+    This class enables users to format date variables using strftime format codes
+    in their filename templates. For example:
+    - {issue_release_date} → "1963-03-01" (default)
+    - {issue_release_date:%Y} → "1963" (year)
+    - {issue_release_date:%m} → "03" (month number)
+    - {issue_release_date:%B} → "March" (full month name)
+    - {issue_release_date:%b} → "Mar" (abbreviated month name)
+    - {issue_release_date:%Y-%m} → "1963-03" (year-month)
+    """
+    
+    def __init__(self, date_string: Union[str, None]):
+        """Initialize with a date string in YYYY-MM-DD format.
+        
+        Args:
+            date_string: Date string in YYYY-MM-DD format or None
+        """
+        self.date_string = date_string
+        self._date_obj = None
+        if date_string:
+            try:
+                # Parse YYYY-MM-DD format
+                self._date_obj = datetime.strptime(date_string, '%Y-%m-%d')
+            except (ValueError, TypeError):
+                pass
+    
+    def __str__(self):
+        """Default string representation (full date in YYYY-MM-DD format)."""
+        return self.date_string if self.date_string else 'Unknown'
+    
+    def __format__(self, format_spec):
+        """Handle format specifications using strftime format codes.
+        
+        Args:
+            format_spec: strftime format string (e.g., '%Y', '%B', '%Y-%m')
+        
+        Returns:
+            Formatted date string or 'Unknown' if date cannot be formatted
+        """
+        if not format_spec:
+            # No format spec, return default YYYY-MM-DD
+            return str(self)
+        
+        if not self._date_obj:
+            # Can't parse date, return as-is or Unknown
+            return str(self)
+        
+        try:
+            # Treat format spec as strftime format
+            return self._date_obj.strftime(format_spec)
+        except (ValueError, TypeError):
+            # Invalid format spec, return default
+            return str(self)
 
 
 # =====================
@@ -164,7 +226,7 @@ def _get_issue_naming_keys(
             or None
         ),
         issue_title=clean_filestring(issue_data.title or '') or None,
-        issue_release_date=issue_data.date,
+        issue_release_date=DateFormatter(issue_data.date),
         issue_release_year=extract_year_from_date(issue_data.date)
     )
 
@@ -407,7 +469,7 @@ def check_format(format: str, type: str) -> bool:
         return False
 
     keys = [
-        fn
+        fn.split(':')[0]  # Extract field name before format spec (e.g., 'issue_release_date' from 'issue_release_date:%Y')
         for _, fn, _, _ in Formatter().parse(format)
         if fn is not None
     ]

--- a/docs/settings/mediamanagement.md
+++ b/docs/settings/mediamanagement.md
@@ -49,6 +49,21 @@ The naming format for the file itself.
 	| {issue_release_date} | 1963-03-01 |
 	| {issue_release_year} | 1963 |
 
+??? info "Date Formatting"
+	The `{issue_release_date}` variable supports strftime format codes for flexible date formatting.
+	
+	| Format Code | Meaning | Example |
+	| ----------- | ------- | ------- |
+	| {issue_release_date:%Y} | Year (4 digits) | 1963 |
+	| {issue_release_date:%m} | Month (zero-padded) | 03 |
+	| {issue_release_date:%d} | Day (zero-padded) | 01 |
+	| {issue_release_date:%B} | Full month name | March |
+	| {issue_release_date:%b} | Abbreviated month name | Mar |
+	| {issue_release_date:%Y-%m} | Year-Month | 1963-03 |
+	| {issue_release_date:%B %Y} | Month Year | March 1963 |
+	
+	For a complete list of format codes, see [Python's strftime documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).
+
 | Example Value | Example Resulting Name |
 | ------------- | -------------- |
 | {series_name} ({year}) Volume {volume_number} Issue \{issue_number\} | Deadpool (1994) Volume 01 Issue 002 |
@@ -73,6 +88,10 @@ If the value of the setting [File Naming](#file-naming_1) uses the issue title, 
 	| {issue_number} | 001 |
 	| {issue_release_date} | 1963-03-01 |
 	| {issue_release_year} | 1963 |
+
+??? info "Date Formatting"
+	The `{issue_release_date}` variable supports strftime format codes for flexible date formatting.
+	See [Date Formatting section above](#file-naming) for details.
 
 | Example Value | Example Resulting Name |
 | ------- | -------------- |
@@ -116,6 +135,10 @@ The naming format for the file itself (if it's a Volume As Issue, so an issue na
 	| {issue_title} | Spider-Man; Spider-Man Vs. The Chameleon |
 	| {issue_release_date} | 1963-03-01 |
 	| {issue_release_year} | 1963 |
+
+??? info "Date Formatting"
+	The `{issue_release_date}` variable supports strftime format codes for flexible date formatting.
+	See [Date Formatting section above](#file-naming) for details.
 
 | Example Value | Example Resulting Name |
 | ------------- | -------------- |

--- a/frontend/templates/settings_mediamanagement.html
+++ b/frontend/templates/settings_mediamanagement.html
@@ -42,17 +42,19 @@
 					<tr>
 						<th><label for="file-naming-input">File Naming</label></th>
 						<td>
-							<input type="text" id="file-naming-input" required spellcheck="false">
-							<p>The naming format for the file itself.</p>
-							<p>Available variables are: {series_name}, {clean_series_name}, {volume_number}, {comicvine_id}, {year}, {publisher}, {issue_comicvine_id}, {issue_number}, {issue_title}, {issue_release_date} and {issue_release_year}</p>
+						<input type="text" id="file-naming-input" required spellcheck="false">
+						<p>The naming format for the file itself.</p>
+						<p>Available variables are: {series_name}, {clean_series_name}, {volume_number}, {comicvine_id}, {year}, {publisher}, {issue_comicvine_id}, {issue_number}, {issue_title}, {issue_release_date} and {issue_release_year}</p>
+						<p>Date formatting: {issue_release_date} supports strftime format codes (e.g., {issue_release_date:%Y} for year, {issue_release_date:%B} for month name, {issue_release_date:%m} for month number)</p>
 						</td>
 					</tr>
 					<tr>
 						<th><label for="file-naming-empty-input">File Naming For <br>Issues Without Title</label></th>
 						<td>
-							<input type="text" id="file-naming-empty-input" required spellcheck="false">
-							<p>The naming format for the file itself if there is no issue title.</p>
-							<p>Available variables are: {series_name}, {clean_series_name}, {volume_number}, {comicvine_id}, {year}, {publisher}, {issue_comicvine_id}, {issue_number}, {issue_release_date} and {issue_release_year}</p>
+						<input type="text" id="file-naming-empty-input" required spellcheck="false">
+						<p>The naming format for the file itself if there is no issue title.</p>
+						<p>Available variables are: {series_name}, {clean_series_name}, {volume_number}, {comicvine_id}, {year}, {publisher}, {issue_comicvine_id}, {issue_number}, {issue_release_date} and {issue_release_year}</p>
+						<p>Date formatting: {issue_release_date} supports strftime format codes (e.g., {issue_release_date:%Y} for year, {issue_release_date:%B} for month name, {issue_release_date:%m} for month number)</p>
 						</td>
 					</tr>
 					<tr>
@@ -66,9 +68,10 @@
 					<tr>
 						<th><label for="file-naming-vai-input">File Naming For <br>"Volume As Issue"</label></th>
 						<td>
-							<input type="text" id="file-naming-vai-input" required spellcheck="false">
-							<p>The naming format for the file itself (if it's a Volume As Issue, so an issue named "Volume N").</p>
-							<p>Available variables are: {series_name}, {clean_series_name}, {volume_number}, {comicvine_id}, {year}, {publisher}, {issue_comicvine_id}, {issue_number}, {issue_title}, {issue_release_date} and {issue_release_year}</p>
+						<input type="text" id="file-naming-vai-input" required spellcheck="false">
+						<p>The naming format for the file itself (if it's a Volume As Issue, so an issue named "Volume N").</p>
+						<p>Available variables are: {series_name}, {clean_series_name}, {volume_number}, {comicvine_id}, {year}, {publisher}, {issue_comicvine_id}, {issue_number}, {issue_title}, {issue_release_date} and {issue_release_year}</p>
+						<p>Date formatting: {issue_release_date} supports strftime format codes (e.g., {issue_release_date:%Y} for year, {issue_release_date:%B} for month name, {issue_release_date:%m} for month number)</p>
 						</td>
 					</tr>
 					<tr>


### PR DESCRIPTION
This PR implements flexible date formatting for the `issue_release_date` variable in filename templates using strftime format codes.

## Changes
- Added `DateFormatter` class that wraps date strings and implements `__format__`
- Enables strftime format codes in filename templates
- Updated `_get_issue_naming_keys` to wrap `issue_release_date` in `DateFormatter`
- Updated `check_format` to handle format specs in validation (splits field name from format code)
- Updated `IssueNamingKeys` type hint to support `DateFormatter`
- Added documentation in templates with common format codes
- Added comprehensive documentation in markdown files with examples

## Usage Examples
Users can now format dates flexibly:
- `{issue_release_date:%Y}` → "1963" (year)
- `{issue_release_date:%m}` → "03" (month number, zero-padded)
- `{issue_release_date:%d}` → "01" (day, zero-padded)
- `{issue_release_date:%B}` → "March" (full month name)
- `{issue_release_date:%b}` → "Mar" (abbreviated month name)
- `{issue_release_date:%Y-%m}` → "1963-03" (year-month)
- `{issue_release_date:%B %Y}` → "March 1963" (month year)

For a complete list of format codes, see [Python's strftime documentation](https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes).

## Backward Compatibility
- `{issue_release_date}` without format spec continues to return YYYY-MM-DD format
- `{issue_release_year}` variable is kept for backward compatibility, though it can now be replaced with `{issue_release_date:%Y}`

## Testing
- Tested with various format codes
- Format validation handles format specs correctly
- Backward compatible with existing configurations

Fixes #293