### PR TITLE
fix(volumes): use v.id instead of i.volume_id in refresh_and_scan GROUP BY

### DIFF
--- a/backend/implementations/volumes.py
+++ b/backend/implementations/volumes.py
@@ -1420,7 +1420,7 @@ def refresh_and_scan(
             LEFT JOIN issues i
             ON v.id = i.volume_id
             WHERE v.last_cv_fetch <= ?
-            GROUP BY i.volume_id;
+            GROUP BY v.id;
             """,
             (one_day_ago.timestamp(),)
         ))


### PR DESCRIPTION
Fixes #320

When a volume has zero issues, `GROUP BY i.volume_id` produces no rows because the LEFT JOIN yields NULL for all issue columns. Grouping by `v.id` ensures every volume appears in the result regardless of issue count.