### PR TITLE
fix(mediafire): prevent KeyError when data-scrambled-url attribute is missing

### DIFF
--- a/backend/implementations/download_clients.py
+++ b/backend/implementations/download_clients.py
@@ -444,15 +444,14 @@ class MediaFireDownload(BaseDirectDownload):
             raise LinkBroken(self.download_link)
 
         href: str = first_of_range(button['href'])
-        data_scrambled_url: str = first_of_range(button['data-scrambled-url'])
         if href.startswith('http'):
-            return first_of_range(button['href'])
+            return href
 
-        elif data_scrambled_url:
-            return b64decode(data_scrambled_url).decode('utf-8')
+        data_scrambled_url = button.get('data-scrambled-url')
+        if data_scrambled_url:
+            return b64decode(first_of_range(data_scrambled_url)).decode('utf-8')
 
-        else:
-            raise LinkBroken(self.download_link)
+        raise LinkBroken(self.download_link)
 
 
 # region MediaFire Folder


### PR DESCRIPTION
Fixes #322

When a MediaFire download page lacks the `data-scrambled-url` attribute on the download button, accessing it via `button['data-scrambled-url']` raises a `KeyError`, crashing the download. Uses `button.get()` for safe access instead, with `first_of_range()` to satisfy the type checker since BeautifulSoup returns `Union[None, str, List[str]]`.

Also removes a redundant `first_of_range()` call on the `href` return path (already resolved on the prior line).