### PR TITLE
fix(tasks): use LEFT JOIN so tasks without run history appear on Tasks page

### DIFF
--- a/backend/features/tasks.py
+++ b/backend/features/tasks.py
@@ -787,7 +787,7 @@ def get_task_planning() -> List[dict]:
         SELECT
             i.task_name, interval, next_run, run_at AS last_run
         FROM task_intervals i
-        INNER JOIN (
+        LEFT JOIN (
             SELECT
                 task_name,
                 MAX(run_at) AS run_at

--- a/frontend/static/js/tasks.js
+++ b/frontend/static/js/tasks.js
@@ -20,6 +20,7 @@ function convertInterval(interval) {
 };
 
 function convertTime(epoch, future) {
+	if (epoch === null) return 'Never';
 	result = Math.round(Math.abs(Date.now() / 1000 - epoch) / 3600); // delta hours
 	if (future) return `in ${result} hours`;
 	else return `${result} hours ago`;


### PR DESCRIPTION
Fixes #321

The Tasks page uses INNER JOIN between task_intervals and task_history, which excludes tasks that have never run. Changing to LEFT JOIN ensures all scheduled tasks are visible. Also adds a null guard in the frontend so tasks that have never run display 'Never' instead of a nonsensical timestamp.

_Replaces #326, which was auto-closed when the fork was briefly set to private._