### PR TITLE
feat(ui): ComicVine rate limit status checker and inline feedback

### DIFF
--- a/Kapowarr.py
+++ b/Kapowarr.py
@@ -87,7 +87,7 @@ def _main(
     with SERVER.app.app_context():
         StartTypeHandlers.start_timer(start_type)
         setup_db()
-        StatusHandlers.load_from_db()
+        StatusHandlers().load_from_db()
 
         s = Settings()
 

--- a/Kapowarr.py
+++ b/Kapowarr.py
@@ -72,6 +72,7 @@ def _main(
     from backend.internals.db import set_db_location, setup_db
     from backend.internals.server import Server, StartTypeHandlers
     from backend.internals.settings import Settings
+    from backend.internals.status import StatusHandlers
 
     set_start_method('spawn')
     setup_logging(log_folder, log_file)
@@ -86,6 +87,7 @@ def _main(
     with SERVER.app.app_context():
         StartTypeHandlers.start_timer(start_type)
         setup_db()
+        StatusHandlers.load_from_db()
 
         s = Settings()
 

--- a/backend/base/definitions.py
+++ b/backend/base/definitions.py
@@ -261,6 +261,16 @@ class WebSocketEventType(BaseEnum):
     DOWNLOADED_STATUS = "downloaded_status"
     "A change in what issues are marked as downloaded and which aren't"
 
+    STATUS_COUNT = "status_count"
+    "A change in the number of active status issues"
+
+
+class StatusType(BaseEnum):
+    "A type of status issue that can be reported"
+
+    CV_RATE_LIMIT = "cv_rate_limit"
+    "ComicVine API rate limit reached"
+
 
 class StartType(BaseEnum):
     "The reason for or cause of starting up"
@@ -839,6 +849,59 @@ class StartTypeHandler(ABC):
     def on_diffuse(self) -> None:
         """
         Called when the timer is diffused. Generally finalises changes.
+        """
+        ...
+
+
+class StatusHandler(ABC):
+    "A handler for a specific status type"
+
+    description: str
+    """A short description of what the status type represents"""
+
+    @abstractmethod
+    def get_expiry(
+        self, subtype: str, timestamp: float
+    ) -> Union[float, None]:
+        """Get the absolute expiry timestamp for this subtype.
+
+        Args:
+            subtype (str): The subtype identifier.
+            timestamp (float): When the status was first reported.
+
+        Returns:
+            Union[float, None]: The absolute expiry timestamp, or None if
+                the status should persist until manually cleared.
+        """
+        ...
+
+    @abstractmethod
+    def on_report(self, subtype: str) -> None:
+        """Called when a status is reported. For additional side effects.
+
+        Args:
+            subtype (str): The subtype that was reported.
+        """
+        ...
+
+    @abstractmethod
+    def on_clear(self) -> None:
+        """Called when the status is fully cleared (all subtypes gone)."""
+        ...
+
+    @abstractmethod
+    def get_display(
+        self,
+        subtypes: Dict[str, 'Tuple[float, Union[float, None]]']
+    ) -> Dict[str, Any]:
+        """Return formatted display data for the API and status page.
+
+        Args:
+            subtypes (Dict[str, Tuple[float, Union[float, None]]]): A mapping
+                from subtype name to (timestamp, expires_at).
+
+        Returns:
+            Dict[str, Any]: The formatted data.
         """
         ...
 

--- a/backend/base/definitions.py
+++ b/backend/base/definitions.py
@@ -859,46 +859,85 @@ class StatusHandler(ABC):
     description: str
     """A short description of what the status type represents"""
 
-    @abstractmethod
     def get_expiry(
-        self, subtype: str, timestamp: float
-    ) -> Union[float, None]:
+        self, subtype: str, timestamp: int
+    ) -> Union[int, None]:
         """Get the absolute expiry timestamp for this subtype.
+        Override in handlers that auto-expire. Defaults to None
+        (no auto-expiry, persists until manually cleared).
 
         Args:
             subtype (str): The subtype identifier.
-            timestamp (float): When the status was first reported.
+            timestamp (int): When the status was reported (epoch seconds).
 
         Returns:
-            Union[float, None]: The absolute expiry timestamp, or None if
-                the status should persist until manually cleared.
+            Union[int, None]: The absolute expiry timestamp, or None.
+        """
+        return None
+
+    @abstractmethod
+    def report(self, subtype: str, timestamp: int) -> None:
+        """Report a status issue. Store the subtype and manage timers.
+
+        Args:
+            subtype (str): The subtype identifier.
+            timestamp (int): When the status was reported (epoch seconds).
         """
         ...
 
     @abstractmethod
-    def on_report(self, subtype: str) -> None:
-        """Called when a status is reported. For additional side effects.
+    def clear(self, subtype: Union[str, None] = None) -> None:
+        """Clear a subtype or all subtypes. Cancel associated timers.
 
         Args:
-            subtype (str): The subtype that was reported.
+            subtype (Union[str, None], optional): The subtype to clear.
+                If None, clear all subtypes. Defaults to None.
         """
         ...
 
     @abstractmethod
-    def on_clear(self) -> None:
-        """Called when the status is fully cleared (all subtypes gone)."""
+    def problem_reported(
+        self, subtype: Union[str, None] = None
+    ) -> bool:
+        """Check if a problem is reported for this handler.
+
+        Args:
+            subtype (Union[str, None], optional): Check a specific subtype.
+                If None, check if any subtype is active. Defaults to None.
+
+        Returns:
+            bool: Whether the problem is reported.
+        """
         ...
 
     @abstractmethod
-    def get_display(
-        self,
-        subtypes: Dict[str, 'Tuple[float, Union[float, None]]']
-    ) -> Dict[str, Any]:
-        """Return formatted display data for the API and status page.
+    def restore(
+        self, subtype: str, timestamp: int,
+        remaining: Union[int, None]
+    ) -> None:
+        """Restore a subtype from database on startup.
 
         Args:
-            subtypes (Dict[str, Tuple[float, Union[float, None]]]): A mapping
-                from subtype name to (timestamp, expires_at).
+            subtype (str): The subtype identifier.
+            timestamp (int): The stored timestamp.
+            remaining (Union[int, None]): Seconds until expiry, or None
+                if the status has no auto-expiry.
+        """
+        ...
+
+    @abstractmethod
+    def get_subtypes(self) -> Dict[str, int]:
+        """Get the current subtypes and their timestamps.
+
+        Returns:
+            Dict[str, int]: A mapping from subtype to timestamp.
+        """
+        ...
+
+    @abstractmethod
+    def get_display(self) -> Dict[str, Any]:
+        """Return display data for the API. Subtype labels should be
+        handled in the frontend, not here.
 
         Returns:
             Dict[str, Any]: The formatted data.

--- a/backend/implementations/comicvine.py
+++ b/backend/implementations/comicvine.py
@@ -463,7 +463,7 @@ class ComicVine:
                     f'/volume/{cv_id}',
                     {'field_list': self.volume_field_list}
                 )
-                StatusHandlers.clear(StatusType.CV_RATE_LIMIT, "fetch_volume")
+                StatusHandlers().clear(StatusType.CV_RATE_LIMIT, "fetch_volume")
 
                 volume_info = self.__format_volume_output(result['results'])
                 volume_info['issues'] = await self.fetch_issues((cv_id,))
@@ -478,7 +478,7 @@ class ComicVine:
                 return volume_info
 
         except CVRateLimitReached:
-            StatusHandlers.report(StatusType.CV_RATE_LIMIT, "fetch_volume")
+            StatusHandlers().report(StatusType.CV_RATE_LIMIT, "fetch_volume")
             raise
 
     async def fetch_volumes(
@@ -594,10 +594,10 @@ class ComicVine:
                             'filter': f'volume:{batch_filter}'
                         }
                     )
-                    StatusHandlers.clear(StatusType.CV_RATE_LIMIT, "fetch_issues")
+                    StatusHandlers().clear(StatusType.CV_RATE_LIMIT, "fetch_issues")
 
                 except CVRateLimitReached:
-                    StatusHandlers.report(StatusType.CV_RATE_LIMIT, "fetch_issues")
+                    StatusHandlers().report(StatusType.CV_RATE_LIMIT, "fetch_issues")
                     break
 
                 issue_infos.extend((
@@ -694,13 +694,13 @@ class ComicVine:
                 results = await self.__search_volume(query)
             else:
                 results = await self.__search_query(query)
-            StatusHandlers.clear(StatusType.CV_RATE_LIMIT, "search_volumes")
+            StatusHandlers().clear(StatusType.CV_RATE_LIMIT, "search_volumes")
 
         except VolumeNotMatched:
             return []
 
         except CVRateLimitReached:
-            StatusHandlers.report(StatusType.CV_RATE_LIMIT, "search_volumes")
+            StatusHandlers().report(StatusType.CV_RATE_LIMIT, "search_volumes")
             if allow_rate_limit_reached:
                 return []
             raise

--- a/backend/implementations/comicvine.py
+++ b/backend/implementations/comicvine.py
@@ -16,8 +16,8 @@ from bs4 import BeautifulSoup, Tag
 from backend.base.custom_exceptions import (CVRateLimitReached,
                                             InvalidComicVineApiKey,
                                             VolumeNotMatched)
-from backend.base.definitions import (Constants, FilenameData,
-                                      IssueMetadata, T, VolumeMetadata)
+from backend.base.definitions import (Constants, FilenameData, IssueMetadata,
+                                      StatusType, T, VolumeMetadata)
 from backend.base.file_extraction import (extract_issue_number,
                                           extract_volume_number, volume_regex)
 from backend.base.helpers import (AsyncSession, Session, batched,
@@ -28,6 +28,7 @@ from backend.base.logging import LOGGER
 from backend.implementations.matching import select_best_volume_result_for_file
 from backend.internals.db import get_db
 from backend.internals.settings import Settings
+from backend.internals.status import StatusHandlers
 
 translation_regex = compile(
     r'^<p>\s*\w+(?<!English) publication(\.?</p>$|,\s| \(in the \w+(?<!English) language\)|, translates )|' +
@@ -455,24 +456,30 @@ class ComicVine:
 
         LOGGER.debug(f'Fetching volume data for {cv_id}')
 
-        async with AsyncSession() as session:
-            result = await self.__call_api(
-                session,
-                f'/volume/{cv_id}',
-                {'field_list': self.volume_field_list}
-            )
+        try:
+            async with AsyncSession() as session:
+                result = await self.__call_api(
+                    session,
+                    f'/volume/{cv_id}',
+                    {'field_list': self.volume_field_list}
+                )
+                StatusHandlers.clear(StatusType.CV_RATE_LIMIT, "fetch_volume")
 
-            volume_info = self.__format_volume_output(result['results'])
-            volume_info['issues'] = await self.fetch_issues((cv_id,))
+                volume_info = self.__format_volume_output(result['results'])
+                volume_info['issues'] = await self.fetch_issues((cv_id,))
 
-            LOGGER.debug('Fetching volume data result: %s', volume_info)
+                LOGGER.debug('Fetching volume data result: %s', volume_info)
 
-            volume_info['cover'] = await session.get_content(
-                volume_info['cover_link'],
-                quiet_fail=True
-            ) or None
+                volume_info['cover'] = await session.get_content(
+                    volume_info['cover_link'],
+                    quiet_fail=True
+                ) or None
 
-            return volume_info
+                return volume_info
+
+        except CVRateLimitReached:
+            StatusHandlers.report(StatusType.CV_RATE_LIMIT, "fetch_volume")
+            raise
 
     async def fetch_volumes(
         self,
@@ -587,8 +594,10 @@ class ComicVine:
                             'filter': f'volume:{batch_filter}'
                         }
                     )
+                    StatusHandlers.clear(StatusType.CV_RATE_LIMIT, "fetch_issues")
 
                 except CVRateLimitReached:
+                    StatusHandlers.report(StatusType.CV_RATE_LIMIT, "fetch_issues")
                     break
 
                 issue_infos.extend((
@@ -654,8 +663,7 @@ class ComicVine:
                     'resources': 'volume',
                     'limit': 50,
                     'field_list': self.search_field_list
-                },
-                {'results': []}
+                }
             )
             return results['results']
 
@@ -686,11 +694,13 @@ class ComicVine:
                 results = await self.__search_volume(query)
             else:
                 results = await self.__search_query(query)
+            StatusHandlers.clear(StatusType.CV_RATE_LIMIT, "search_volumes")
 
         except VolumeNotMatched:
             return []
 
         except CVRateLimitReached:
+            StatusHandlers.report(StatusType.CV_RATE_LIMIT, "search_volumes")
             if allow_rate_limit_reached:
                 return []
             raise

--- a/backend/internals/db.py
+++ b/backend/internals/db.py
@@ -531,8 +531,8 @@ CREATE TABLE IF NOT EXISTS remote_mappings(
 CREATE TABLE IF NOT EXISTS status(
     status_type VARCHAR(100) NOT NULL,
     subtype VARCHAR(100) NOT NULL,
-    timestamp REAL NOT NULL,
-    expires_at REAL,
+    timestamp INTEGER NOT NULL,
+    expires_at INTEGER,
     PRIMARY KEY (status_type, subtype)
 );
 """

--- a/backend/internals/db.py
+++ b/backend/internals/db.py
@@ -528,4 +528,11 @@ CREATE TABLE IF NOT EXISTS remote_mappings(
         REFERENCES external_download_clients(id)
         ON DELETE CASCADE
 );
+CREATE TABLE IF NOT EXISTS status(
+    status_type VARCHAR(100) NOT NULL,
+    subtype VARCHAR(100) NOT NULL,
+    timestamp REAL NOT NULL,
+    expires_at REAL,
+    PRIMARY KEY (status_type, subtype)
+);
 """

--- a/backend/internals/db_migration.py
+++ b/backend/internals/db_migration.py
@@ -1184,18 +1184,3 @@ def _migrate_add_forced_file_match_column():
     """)
 
     return
-
-
-@DatabaseMigrationHandler.register_handler(45)
-def _migrate_add_status_table():
-    get_db().executescript("""
-        CREATE TABLE IF NOT EXISTS status(
-            status_type VARCHAR(100) NOT NULL,
-            subtype VARCHAR(100) NOT NULL,
-            timestamp REAL NOT NULL,
-            expires_at REAL,
-            PRIMARY KEY (status_type, subtype)
-        );
-    """)
-
-    return

--- a/backend/internals/db_migration.py
+++ b/backend/internals/db_migration.py
@@ -1184,3 +1184,18 @@ def _migrate_add_forced_file_match_column():
     """)
 
     return
+
+
+@DatabaseMigrationHandler.register_handler(45)
+def _migrate_add_status_table():
+    get_db().executescript("""
+        CREATE TABLE IF NOT EXISTS status(
+            status_type VARCHAR(100) NOT NULL,
+            subtype VARCHAR(100) NOT NULL,
+            timestamp REAL NOT NULL,
+            expires_at REAL,
+            PRIMARY KEY (status_type, subtype)
+        );
+    """)
+
+    return

--- a/backend/internals/server.py
+++ b/backend/internals/server.py
@@ -591,6 +591,27 @@ class DownloadedStatusEvent(WebSocketEvent):
         }
 
 
+class StatusCountEvent(WebSocketEvent):
+    "The number of active status issues has changed"
+
+    def __init__(self, count: int) -> None:
+        """Create the event.
+
+        Args:
+            count (int): The total number of active status types.
+        """
+        self.count = count
+        return
+
+    def get_type(self) -> WebSocketEventType:
+        return WebSocketEventType.STATUS_COUNT
+
+    def get_body(self) -> Dict[str, Any]:
+        return {
+            "count": self.count
+        }
+
+
 # region StartType Handling
 class StartTypeHandlers:
     handlers: dict[StartType, StartTypeHandler] = {}

--- a/backend/internals/status.py
+++ b/backend/internals/status.py
@@ -6,34 +6,33 @@ Status type implementations register via decorator and are persisted
 to the database across restarts.
 """
 
-from threading import Lock, Timer
+from threading import Timer
 from time import time
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import Any, Callable, Dict, List, Type, Union
 
 from backend.base.definitions import StatusHandler, StatusType
+from backend.base.helpers import Singleton
 from backend.base.logging import LOGGER
 from backend.internals.db import get_db
+from backend.internals.server import Server, StatusCountEvent, WebSocket
 
 
-class StatusHandlers:
+class StatusHandlers(metaclass=Singleton):
     """Registry and manager for status type handlers.
     Modeled after StartTypeHandlers in server.py.
+
+    Handlers register via the class-level register_handler() decorator
+    at import time. All other methods are instance methods accessed via
+    StatusHandlers().
     """
 
     handlers: Dict[StatusType, StatusHandler] = {}
-    _active: Dict[StatusType, Dict[str, Tuple[float, Union[float, None]]]] = {}
-    """In-memory state: {type: {subtype: (timestamp, expires_at)}}"""
-    _timers: Dict[str, Timer] = {}
-    """Expiry timers keyed by 'type.subtype'"""
-    _lock = Lock()
 
     @classmethod
     def register_handler(
         cls,
         status_type: StatusType
-    ) -> Callable[
-        ['type[StatusHandler]'], 'type[StatusHandler]'
-    ]:
+    ) -> Callable[[Type[StatusHandler]], Type[StatusHandler]]:
         """Register a handler for a status type.
 
         ```
@@ -47,14 +46,13 @@ class StatusHandlers:
                 is for.
         """
         def wrapper(
-            handler_class: 'type[StatusHandler]'
-        ) -> 'type[StatusHandler]':
+            handler_class: Type[StatusHandler]
+        ) -> Type[StatusHandler]:
             cls.handlers[status_type] = handler_class()
             return handler_class
         return wrapper
 
-    @classmethod
-    def report(cls, status_type: StatusType, subtype: str) -> None:
+    def report(self, status_type: StatusType, subtype: str) -> None:
         """Report a status issue.
 
         Args:
@@ -62,44 +60,38 @@ class StatusHandlers:
             subtype (str): The subtype identifier
                 (e.g. "search_volumes" for CV rate limit).
         """
-        handler = cls.handlers.get(status_type)
-        if handler is None:
-            return
+        handler = self.handlers[status_type]
+        timestamp = int(time())
 
-        timestamp = time()
-        timer_key = f"{status_type.value}.{subtype}"
+        was_active = handler.problem_reported(subtype)
+        handler.report(subtype, timestamp)
 
-        with cls._lock:
-            type_statuses = cls._active.setdefault(status_type, {})
-            existing = type_statuses.get(subtype)
+        if was_active:
+            # Update timestamp in DB but keep existing expires_at
+            get_db().execute(
+                "UPDATE status SET timestamp = ? "
+                "WHERE status_type = ? AND subtype = ?;",
+                (timestamp, status_type.value, subtype)
+            )
+        else:
+            # New subtype: get expiry from handler's subtypes
+            expires_at = self._get_expires_at(handler, subtype, timestamp)
+            get_db().execute(
+                "INSERT OR REPLACE INTO status "
+                "(status_type, subtype, timestamp, expires_at) "
+                "VALUES (?, ?, ?, ?);",
+                (status_type.value, subtype, timestamp, expires_at)
+            )
 
-            if existing is not None:
-                # Subtype already active: update timestamp, keep expires_at
-                type_statuses[subtype] = (timestamp, existing[1])
-                cls._save_to_db(status_type, subtype,
-                                timestamp, existing[1])
-            else:
-                # New subtype
-                expires_at = handler.get_expiry(subtype, timestamp)
-                type_statuses[subtype] = (timestamp, expires_at)
-                cls._save_to_db(status_type, subtype,
-                                timestamp, expires_at)
-                cls._schedule_expiry(
-                    status_type, subtype, expires_at, timer_key
-                )
-
-        handler.on_report(subtype)
-        cls._emit_count()
-
+        self._emit_count()
         LOGGER.info(
             "Status reported: %s / %s",
             status_type.value, subtype
         )
         return
 
-    @classmethod
     def clear(
-        cls,
+        self,
         status_type: StatusType,
         subtype: Union[str, None] = None
     ) -> None:
@@ -111,71 +103,44 @@ class StatusHandlers:
                 If None, clears all subtypes for this type.
                 Defaults to None.
         """
-        handler = cls.handlers.get(status_type)
+        handler = self.handlers[status_type]
 
-        with cls._lock:
-            type_statuses = cls._active.get(status_type)
-            if type_statuses is None:
-                return
+        if not handler.problem_reported(subtype):
+            return
 
-            if subtype is not None:
-                if subtype not in type_statuses:
-                    return
-                del type_statuses[subtype]
-                cls._delete_from_db(status_type, subtype)
-                cls._cancel_timer(f"{status_type.value}.{subtype}")
+        handler.clear(subtype)
 
-                if not type_statuses:
-                    del cls._active[status_type]
-                    fully_cleared = True
-                else:
-                    fully_cleared = False
-            else:
-                # Clear all subtypes
-                for st in list(type_statuses):
-                    cls._cancel_timer(f"{status_type.value}.{st}")
-                    cls._delete_from_db(status_type, st)
-                del cls._active[status_type]
-                fully_cleared = True
+        if subtype is not None:
+            get_db().execute(
+                "DELETE FROM status "
+                "WHERE status_type = ? AND subtype = ?;",
+                (status_type.value, subtype)
+            )
+        else:
+            get_db().execute(
+                "DELETE FROM status WHERE status_type = ?;",
+                (status_type.value,)
+            )
 
-        if fully_cleared and handler is not None:
-            handler.on_clear()
-
-        cls._emit_count()
-
-        LOGGER.info(
-            "Status cleared: %s%s",
-            status_type.value,
-            f" / {subtype}" if subtype else " (all)"
-        )
+        self._emit_count()
         return
 
-    @classmethod
-    def clear_all(cls) -> None:
+    def clear_all(self) -> None:
         """Clear all status issues."""
-        with cls._lock:
-            for status_type in list(cls._active):
-                for st in list(cls._active.get(status_type, {})):
-                    cls._cancel_timer(f"{status_type.value}.{st}")
-                    cls._delete_from_db(status_type, st)
+        for status_type, handler in self.handlers.items():
+            if handler.problem_reported():
+                handler.clear()
 
-                handler = cls.handlers.get(status_type)
-                if handler is not None:
-                    handler.on_clear()
-
-            cls._active.clear()
-
-        cls._emit_count()
-        LOGGER.info("All statuses cleared")
+        get_db().execute("DELETE FROM status;")
+        self._emit_count()
         return
 
-    @classmethod
-    def is_active(
-        cls,
+    def problem_reported(
+        self,
         status_type: StatusType,
         subtype: Union[str, None] = None
     ) -> bool:
-        """Check if a status type (or specific subtype) is currently active.
+        """Check if a problem is reported for a status type.
 
         Args:
             status_type (StatusType): The type to check.
@@ -184,18 +149,12 @@ class StatusHandlers:
                 Defaults to None.
 
         Returns:
-            bool: Whether the status is active.
+            bool: Whether a problem is reported.
         """
-        with cls._lock:
-            type_statuses = cls._active.get(status_type)
-            if type_statuses is None:
-                return False
-            if subtype is not None:
-                return subtype in type_statuses
-            return True
+        handler = self.handlers[status_type]
+        return handler.problem_reported(subtype)
 
-    @classmethod
-    def get_all(cls) -> List[Dict[str, Any]]:
+    def get_all(self) -> List[Dict[str, Any]]:
         """Get all active statuses with display data from handlers.
 
         Returns:
@@ -203,33 +162,29 @@ class StatusHandlers:
                 data provided by each handler.
         """
         result: List[Dict[str, Any]] = []
-        with cls._lock:
-            for status_type, subtypes in cls._active.items():
-                handler = cls.handlers.get(status_type)
-                if handler is None:
-                    continue
-                display = handler.get_display(subtypes.copy())
+        for status_type, handler in self.handlers.items():
+            if handler.problem_reported():
+                display = handler.get_display()
                 display["type"] = status_type.value
                 result.append(display)
         return result
 
-    @classmethod
-    def get_count(cls) -> int:
+    def get_count(self) -> int:
         """Get the total number of active status types.
 
         Returns:
-            int: The count of active status types (not subtypes).
+            int: The count of status types with problems reported.
         """
-        with cls._lock:
-            return len(cls._active)
+        return sum(
+            1 for handler in self.handlers.values()
+            if handler.problem_reported()
+        )
 
-    @classmethod
-    def load_from_db(cls) -> None:
+    def load_from_db(self) -> None:
         """Load status data from the database on startup.
-        Expired entries are deleted. Active entries are restored
-        with timers for remaining time.
+        Expired entries are deleted. Active entries are restored.
         """
-        now = time()
+        now = int(time())
         cursor = get_db()
 
         rows = cursor.execute(
@@ -239,25 +194,10 @@ class StatusHandlers:
 
         for row in rows:
             raw_type, subtype, timestamp, expires_at = row
+            status_type = StatusType(raw_type)
+            handler = self.handlers[status_type]
 
-            # Find the matching StatusType enum
-            try:
-                status_type = StatusType(raw_type)
-            except ValueError:
-                # Unknown status type, remove from DB
-                cursor.execute(
-                    "DELETE FROM status "
-                    "WHERE status_type = ? AND subtype = ?;",
-                    (raw_type, subtype)
-                )
-                continue
-
-            if status_type not in cls.handlers:
-                continue
-
-            # Check expiry
             if expires_at is not None and expires_at <= now:
-                # Expired while offline, remove
                 cursor.execute(
                     "DELETE FROM status "
                     "WHERE status_type = ? AND subtype = ?;",
@@ -269,140 +209,37 @@ class StatusHandlers:
                 )
                 continue
 
-            # Restore active entry
-            with cls._lock:
-                type_statuses = cls._active.setdefault(status_type, {})
-                type_statuses[subtype] = (timestamp, expires_at)
-
-                timer_key = f"{status_type.value}.{subtype}"
-                cls._schedule_expiry(
-                    status_type, subtype, expires_at, timer_key
-                )
-
-            handler = cls.handlers[status_type]
-            handler.on_report(subtype)
-
+            remaining = (expires_at - now) if expires_at is not None else None
+            handler.restore(subtype, timestamp, remaining)
             LOGGER.info(
                 "Restored status from DB: %s / %s",
                 raw_type, subtype
             )
 
-        cls._emit_count()
+        self._emit_count()
         return
 
-    @classmethod
-    def _schedule_expiry(
-        cls,
-        status_type: StatusType,
+    def _get_expires_at(
+        self,
+        handler: StatusHandler,
         subtype: str,
-        expires_at: Union[float, None],
-        timer_key: str
-    ) -> None:
-        """Schedule an expiry timer. Must be called while holding _lock.
+        timestamp: int
+    ) -> Union[int, None]:
+        """Get the expiry timestamp from the handler.
 
         Args:
-            status_type (StatusType): The status type.
+            handler (StatusHandler): The handler.
             subtype (str): The subtype.
-            expires_at (Union[float, None]): When to expire.
-                None means no auto-expiry.
-            timer_key (str): The key for the timer dict.
+            timestamp (int): The report timestamp.
+
+        Returns:
+            Union[int, None]: The expiry timestamp or None.
         """
-        if expires_at is None:
-            return
+        return handler.get_expiry(subtype, timestamp)
 
-        if timer_key in cls._timers:
-            return
-
-        remaining = max(expires_at - time(), 0.001)
-
-        from backend.internals.server import Server
-        timer = Server().get_db_timer_thread(
-            interval=remaining,
-            target=cls._on_expiry,
-            name=f"StatusExpiry.{timer_key}",
-            args=(status_type, subtype)
-        )
-        timer.daemon = True
-        timer.start()
-        cls._timers[timer_key] = timer
-        return
-
-    @classmethod
-    def _on_expiry(cls, status_type: StatusType, subtype: str) -> None:
-        """Called by an expiry timer.
-
-        Args:
-            status_type (StatusType): The status type that expired.
-            subtype (str): The subtype that expired.
-        """
-        timer_key = f"{status_type.value}.{subtype}"
-        with cls._lock:
-            cls._timers.pop(timer_key, None)
-        cls.clear(status_type, subtype)
-        return
-
-    @classmethod
-    def _cancel_timer(cls, timer_key: str) -> None:
-        """Cancel an expiry timer. Must be called while holding _lock.
-
-        Args:
-            timer_key (str): The key for the timer dict.
-        """
-        timer = cls._timers.pop(timer_key, None)
-        if timer is not None:
-            timer.cancel()
-        return
-
-    @classmethod
-    def _save_to_db(
-        cls,
-        status_type: StatusType,
-        subtype: str,
-        timestamp: float,
-        expires_at: Union[float, None]
-    ) -> None:
-        """Save or update a status entry in the database.
-        Must be called while holding _lock.
-
-        Args:
-            status_type (StatusType): The status type.
-            subtype (str): The subtype.
-            timestamp (float): When the status was reported.
-            expires_at (Union[float, None]): When it expires, or None.
-        """
-        get_db().execute(
-            "INSERT OR REPLACE INTO status "
-            "(status_type, subtype, timestamp, expires_at) "
-            "VALUES (?, ?, ?, ?);",
-            (status_type.value, subtype, timestamp, expires_at)
-        )
-        return
-
-    @classmethod
-    def _delete_from_db(
-        cls,
-        status_type: StatusType,
-        subtype: str
-    ) -> None:
-        """Delete a status entry from the database.
-        Must be called while holding _lock.
-
-        Args:
-            status_type (StatusType): The status type.
-            subtype (str): The subtype.
-        """
-        get_db().execute(
-            "DELETE FROM status "
-            "WHERE status_type = ? AND subtype = ?;",
-            (status_type.value, subtype)
-        )
-        return
-
-    @classmethod
-    def _emit_count(cls) -> None:
+    def _emit_count(self) -> None:
         """Emit a WebSocket event with the current status count."""
-        from backend.internals.server import StatusCountEvent, WebSocket
-        count = cls.get_count()
+        count = self.get_count()
         WebSocket().emit(StatusCountEvent(count=count))
         return
 
@@ -419,38 +256,114 @@ class CVRateLimitHandler(StatusHandler):
     """
 
     description = "ComicVine rate limit"
+    EXPIRY_SECONDS = 3600
 
-    _subtype_labels: Dict[str, str] = {
-        "search_volumes": "Searching volumes",
-        "fetch_volume": "Fetching volume metadata",
-        "fetch_issues": "Fetching issue metadata"
-    }
-
-    def get_expiry(
-        self, subtype: str, timestamp: float
-    ) -> Union[float, None]:
-        return timestamp + 3600
-
-    def on_report(self, subtype: str) -> None:
+    def __init__(self) -> None:
+        self._subtypes: Dict[str, int] = {}
+        self._timers: Dict[str, Timer] = {}
         return
 
-    def on_clear(self) -> None:
+    def get_expiry(self, subtype: str, timestamp: int) -> int:
+        """Get the expiry timestamp for a subtype.
+
+        Args:
+            subtype (str): The subtype.
+            timestamp (int): The report timestamp.
+
+        Returns:
+            int: The absolute expiry timestamp.
+        """
+        return timestamp + self.EXPIRY_SECONDS
+
+    def report(self, subtype: str, timestamp: int) -> None:
+        if subtype in self._subtypes:
+            self._subtypes[subtype] = timestamp
+            return
+
+        self._subtypes[subtype] = timestamp
+        self._schedule_timer(subtype, self.EXPIRY_SECONDS)
         return
 
-    def get_display(
-        self,
-        subtypes: Dict[str, Tuple[float, Union[float, None]]]
-    ) -> Dict[str, Any]:
+    def restore(
+        self, subtype: str, timestamp: int,
+        remaining: Union[int, None]
+    ) -> None:
+        """Restore a subtype from database on startup.
+
+        Args:
+            subtype (str): The subtype.
+            timestamp (int): The stored timestamp.
+            remaining (Union[int, None]): Seconds until expiry, or None.
+        """
+        self._subtypes[subtype] = timestamp
+        if remaining is not None:
+            self._schedule_timer(subtype, remaining)
+        return
+
+    def clear(self, subtype: Union[str, None] = None) -> None:
+        if subtype is not None:
+            self._subtypes.pop(subtype, None)
+            self._cancel_timer(subtype)
+        else:
+            self._subtypes.clear()
+            for key in list(self._timers):
+                self._cancel_timer(key)
+        return
+
+    def problem_reported(
+        self, subtype: Union[str, None] = None
+    ) -> bool:
+        if subtype is not None:
+            return subtype in self._subtypes
+        return len(self._subtypes) > 0
+
+    def get_subtypes(self) -> Dict[str, int]:
+        return self._subtypes.copy()
+
+    def get_display(self) -> Dict[str, Any]:
         return {
-            "source": "ComicVine",
             "description": self.description,
-            "subtypes": [
-                {
-                    "name": st,
-                    "label": self._subtype_labels.get(st, st),
-                    "since": data[0],
-                    "expires_at": data[1]
-                }
-                for st, data in subtypes.items()
-            ]
+            "subtypes": list(self._subtypes.keys())
         }
+
+    def _schedule_timer(self, subtype: str, seconds: int) -> None:
+        """Schedule an expiry timer for a subtype.
+
+        Args:
+            subtype (str): The subtype.
+            seconds (int): Seconds until expiry.
+        """
+        if subtype in self._timers:
+            return
+
+        timer = Server().get_db_timer_thread(
+            interval=seconds,
+            target=self._on_expiry,
+            name=f"StatusExpiry.{StatusType.CV_RATE_LIMIT.value}.{subtype}",
+            args=(subtype,)
+        )
+        timer.daemon = True
+        timer.start()
+        self._timers[subtype] = timer
+        return
+
+    def _cancel_timer(self, subtype: str) -> None:
+        """Cancel an expiry timer.
+
+        Args:
+            subtype (str): The subtype.
+        """
+        timer = self._timers.pop(subtype, None)
+        if timer is not None:
+            timer.cancel()
+        return
+
+    def _on_expiry(self, subtype: str) -> None:
+        """Called when a timer fires.
+
+        Args:
+            subtype (str): The subtype that expired.
+        """
+        self._timers.pop(subtype, None)
+        StatusHandlers().clear(StatusType.CV_RATE_LIMIT, subtype)
+        return

--- a/backend/internals/status.py
+++ b/backend/internals/status.py
@@ -1,0 +1,456 @@
+# -*- coding: utf-8 -*-
+
+"""
+General-purpose status tracking framework.
+Status type implementations register via decorator and are persisted
+to the database across restarts.
+"""
+
+from threading import Lock, Timer
+from time import time
+from typing import Any, Callable, Dict, List, Tuple, Union
+
+from backend.base.definitions import StatusHandler, StatusType
+from backend.base.logging import LOGGER
+from backend.internals.db import get_db
+
+
+class StatusHandlers:
+    """Registry and manager for status type handlers.
+    Modeled after StartTypeHandlers in server.py.
+    """
+
+    handlers: Dict[StatusType, StatusHandler] = {}
+    _active: Dict[StatusType, Dict[str, Tuple[float, Union[float, None]]]] = {}
+    """In-memory state: {type: {subtype: (timestamp, expires_at)}}"""
+    _timers: Dict[str, Timer] = {}
+    """Expiry timers keyed by 'type.subtype'"""
+    _lock = Lock()
+
+    @classmethod
+    def register_handler(
+        cls,
+        status_type: StatusType
+    ) -> Callable[
+        ['type[StatusHandler]'], 'type[StatusHandler]'
+    ]:
+        """Register a handler for a status type.
+
+        ```
+        @StatusHandlers.register_handler(StatusType.CV_RATE_LIMIT)
+        class CVRateLimitHandler(StatusHandler):
+            ...
+        ```
+
+        Args:
+            status_type (StatusType): The status type that the handler
+                is for.
+        """
+        def wrapper(
+            handler_class: 'type[StatusHandler]'
+        ) -> 'type[StatusHandler]':
+            cls.handlers[status_type] = handler_class()
+            return handler_class
+        return wrapper
+
+    @classmethod
+    def report(cls, status_type: StatusType, subtype: str) -> None:
+        """Report a status issue.
+
+        Args:
+            status_type (StatusType): The type of status issue.
+            subtype (str): The subtype identifier
+                (e.g. "search_volumes" for CV rate limit).
+        """
+        handler = cls.handlers.get(status_type)
+        if handler is None:
+            return
+
+        timestamp = time()
+        timer_key = f"{status_type.value}.{subtype}"
+
+        with cls._lock:
+            type_statuses = cls._active.setdefault(status_type, {})
+            existing = type_statuses.get(subtype)
+
+            if existing is not None:
+                # Subtype already active: update timestamp, keep expires_at
+                type_statuses[subtype] = (timestamp, existing[1])
+                cls._save_to_db(status_type, subtype,
+                                timestamp, existing[1])
+            else:
+                # New subtype
+                expires_at = handler.get_expiry(subtype, timestamp)
+                type_statuses[subtype] = (timestamp, expires_at)
+                cls._save_to_db(status_type, subtype,
+                                timestamp, expires_at)
+                cls._schedule_expiry(
+                    status_type, subtype, expires_at, timer_key
+                )
+
+        handler.on_report(subtype)
+        cls._emit_count()
+
+        LOGGER.info(
+            "Status reported: %s / %s",
+            status_type.value, subtype
+        )
+        return
+
+    @classmethod
+    def clear(
+        cls,
+        status_type: StatusType,
+        subtype: Union[str, None] = None
+    ) -> None:
+        """Clear a status issue or a specific subtype.
+
+        Args:
+            status_type (StatusType): The type of status issue.
+            subtype (Union[str, None], optional): The subtype to clear.
+                If None, clears all subtypes for this type.
+                Defaults to None.
+        """
+        handler = cls.handlers.get(status_type)
+
+        with cls._lock:
+            type_statuses = cls._active.get(status_type)
+            if type_statuses is None:
+                return
+
+            if subtype is not None:
+                if subtype not in type_statuses:
+                    return
+                del type_statuses[subtype]
+                cls._delete_from_db(status_type, subtype)
+                cls._cancel_timer(f"{status_type.value}.{subtype}")
+
+                if not type_statuses:
+                    del cls._active[status_type]
+                    fully_cleared = True
+                else:
+                    fully_cleared = False
+            else:
+                # Clear all subtypes
+                for st in list(type_statuses):
+                    cls._cancel_timer(f"{status_type.value}.{st}")
+                    cls._delete_from_db(status_type, st)
+                del cls._active[status_type]
+                fully_cleared = True
+
+        if fully_cleared and handler is not None:
+            handler.on_clear()
+
+        cls._emit_count()
+
+        LOGGER.info(
+            "Status cleared: %s%s",
+            status_type.value,
+            f" / {subtype}" if subtype else " (all)"
+        )
+        return
+
+    @classmethod
+    def clear_all(cls) -> None:
+        """Clear all status issues."""
+        with cls._lock:
+            for status_type in list(cls._active):
+                for st in list(cls._active.get(status_type, {})):
+                    cls._cancel_timer(f"{status_type.value}.{st}")
+                    cls._delete_from_db(status_type, st)
+
+                handler = cls.handlers.get(status_type)
+                if handler is not None:
+                    handler.on_clear()
+
+            cls._active.clear()
+
+        cls._emit_count()
+        LOGGER.info("All statuses cleared")
+        return
+
+    @classmethod
+    def is_active(
+        cls,
+        status_type: StatusType,
+        subtype: Union[str, None] = None
+    ) -> bool:
+        """Check if a status type (or specific subtype) is currently active.
+
+        Args:
+            status_type (StatusType): The type to check.
+            subtype (Union[str, None], optional): The subtype to check.
+                If None, checks if any subtype is active.
+                Defaults to None.
+
+        Returns:
+            bool: Whether the status is active.
+        """
+        with cls._lock:
+            type_statuses = cls._active.get(status_type)
+            if type_statuses is None:
+                return False
+            if subtype is not None:
+                return subtype in type_statuses
+            return True
+
+    @classmethod
+    def get_all(cls) -> List[Dict[str, Any]]:
+        """Get all active statuses with display data from handlers.
+
+        Returns:
+            List[Dict[str, Any]]: A list of status entries with display
+                data provided by each handler.
+        """
+        result: List[Dict[str, Any]] = []
+        with cls._lock:
+            for status_type, subtypes in cls._active.items():
+                handler = cls.handlers.get(status_type)
+                if handler is None:
+                    continue
+                display = handler.get_display(subtypes.copy())
+                display["type"] = status_type.value
+                result.append(display)
+        return result
+
+    @classmethod
+    def get_count(cls) -> int:
+        """Get the total number of active status types.
+
+        Returns:
+            int: The count of active status types (not subtypes).
+        """
+        with cls._lock:
+            return len(cls._active)
+
+    @classmethod
+    def load_from_db(cls) -> None:
+        """Load status data from the database on startup.
+        Expired entries are deleted. Active entries are restored
+        with timers for remaining time.
+        """
+        now = time()
+        cursor = get_db()
+
+        rows = cursor.execute(
+            "SELECT status_type, subtype, timestamp, expires_at "
+            "FROM status;"
+        ).fetchall()
+
+        for row in rows:
+            raw_type, subtype, timestamp, expires_at = row
+
+            # Find the matching StatusType enum
+            try:
+                status_type = StatusType(raw_type)
+            except ValueError:
+                # Unknown status type, remove from DB
+                cursor.execute(
+                    "DELETE FROM status "
+                    "WHERE status_type = ? AND subtype = ?;",
+                    (raw_type, subtype)
+                )
+                continue
+
+            if status_type not in cls.handlers:
+                continue
+
+            # Check expiry
+            if expires_at is not None and expires_at <= now:
+                # Expired while offline, remove
+                cursor.execute(
+                    "DELETE FROM status "
+                    "WHERE status_type = ? AND subtype = ?;",
+                    (raw_type, subtype)
+                )
+                LOGGER.info(
+                    "Expired status removed on startup: %s / %s",
+                    raw_type, subtype
+                )
+                continue
+
+            # Restore active entry
+            with cls._lock:
+                type_statuses = cls._active.setdefault(status_type, {})
+                type_statuses[subtype] = (timestamp, expires_at)
+
+                timer_key = f"{status_type.value}.{subtype}"
+                cls._schedule_expiry(
+                    status_type, subtype, expires_at, timer_key
+                )
+
+            handler = cls.handlers[status_type]
+            handler.on_report(subtype)
+
+            LOGGER.info(
+                "Restored status from DB: %s / %s",
+                raw_type, subtype
+            )
+
+        cls._emit_count()
+        return
+
+    @classmethod
+    def _schedule_expiry(
+        cls,
+        status_type: StatusType,
+        subtype: str,
+        expires_at: Union[float, None],
+        timer_key: str
+    ) -> None:
+        """Schedule an expiry timer. Must be called while holding _lock.
+
+        Args:
+            status_type (StatusType): The status type.
+            subtype (str): The subtype.
+            expires_at (Union[float, None]): When to expire.
+                None means no auto-expiry.
+            timer_key (str): The key for the timer dict.
+        """
+        if expires_at is None:
+            return
+
+        if timer_key in cls._timers:
+            return
+
+        remaining = max(expires_at - time(), 0.001)
+
+        from backend.internals.server import Server
+        timer = Server().get_db_timer_thread(
+            interval=remaining,
+            target=cls._on_expiry,
+            name=f"StatusExpiry.{timer_key}",
+            args=(status_type, subtype)
+        )
+        timer.daemon = True
+        timer.start()
+        cls._timers[timer_key] = timer
+        return
+
+    @classmethod
+    def _on_expiry(cls, status_type: StatusType, subtype: str) -> None:
+        """Called by an expiry timer.
+
+        Args:
+            status_type (StatusType): The status type that expired.
+            subtype (str): The subtype that expired.
+        """
+        timer_key = f"{status_type.value}.{subtype}"
+        with cls._lock:
+            cls._timers.pop(timer_key, None)
+        cls.clear(status_type, subtype)
+        return
+
+    @classmethod
+    def _cancel_timer(cls, timer_key: str) -> None:
+        """Cancel an expiry timer. Must be called while holding _lock.
+
+        Args:
+            timer_key (str): The key for the timer dict.
+        """
+        timer = cls._timers.pop(timer_key, None)
+        if timer is not None:
+            timer.cancel()
+        return
+
+    @classmethod
+    def _save_to_db(
+        cls,
+        status_type: StatusType,
+        subtype: str,
+        timestamp: float,
+        expires_at: Union[float, None]
+    ) -> None:
+        """Save or update a status entry in the database.
+        Must be called while holding _lock.
+
+        Args:
+            status_type (StatusType): The status type.
+            subtype (str): The subtype.
+            timestamp (float): When the status was reported.
+            expires_at (Union[float, None]): When it expires, or None.
+        """
+        get_db().execute(
+            "INSERT OR REPLACE INTO status "
+            "(status_type, subtype, timestamp, expires_at) "
+            "VALUES (?, ?, ?, ?);",
+            (status_type.value, subtype, timestamp, expires_at)
+        )
+        return
+
+    @classmethod
+    def _delete_from_db(
+        cls,
+        status_type: StatusType,
+        subtype: str
+    ) -> None:
+        """Delete a status entry from the database.
+        Must be called while holding _lock.
+
+        Args:
+            status_type (StatusType): The status type.
+            subtype (str): The subtype.
+        """
+        get_db().execute(
+            "DELETE FROM status "
+            "WHERE status_type = ? AND subtype = ?;",
+            (status_type.value, subtype)
+        )
+        return
+
+    @classmethod
+    def _emit_count(cls) -> None:
+        """Emit a WebSocket event with the current status count."""
+        from backend.internals.server import StatusCountEvent, WebSocket
+        count = cls.get_count()
+        WebSocket().emit(StatusCountEvent(count=count))
+        return
+
+
+# region Status Handler Implementations
+@StatusHandlers.register_handler(StatusType.CV_RATE_LIMIT)
+class CVRateLimitHandler(StatusHandler):
+    """Handler for ComicVine API rate limit status.
+
+    ComicVine uses a rolling 200-request-per-resource-per-hour window,
+    but the API provides no headers or fields indicating remaining
+    requests or reset timing. Entries expire after one hour from the
+    first rejection. The timer does not reset on subsequent rejections.
+    """
+
+    description = "ComicVine rate limit"
+
+    _subtype_labels: Dict[str, str] = {
+        "search_volumes": "Searching volumes",
+        "fetch_volume": "Fetching volume metadata",
+        "fetch_issues": "Fetching issue metadata"
+    }
+
+    def get_expiry(
+        self, subtype: str, timestamp: float
+    ) -> Union[float, None]:
+        return timestamp + 3600
+
+    def on_report(self, subtype: str) -> None:
+        return
+
+    def on_clear(self) -> None:
+        return
+
+    def get_display(
+        self,
+        subtypes: Dict[str, Tuple[float, Union[float, None]]]
+    ) -> Dict[str, Any]:
+        return {
+            "source": "ComicVine",
+            "description": self.description,
+            "subtypes": [
+                {
+                    "name": st,
+                    "label": self._subtype_labels.get(st, st),
+                    "since": data[0],
+                    "expires_at": data[1]
+                }
+                for st, data in subtypes.items()
+            ]
+        }

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -47,6 +47,7 @@ from backend.implementations.volumes import Library, delete_issue_file
 from backend.internals.db_models import FilesDB
 from backend.internals.server import Server, StartTypeHandlers
 from backend.internals.settings import Settings, get_about_data
+from backend.internals.status import StatusHandlers
 
 api = Blueprint('api', __name__)
 
@@ -284,6 +285,21 @@ def api_public():
 @auth
 def api_about():
     return return_api(get_about_data())
+
+
+# =====================
+# Status Checks
+# =====================
+@api.route('/system/status/checks', methods=['GET', 'DELETE'])
+@error_handler
+@auth
+def api_status_checks():
+    if request.method == 'GET':
+        return return_api(StatusHandlers.get_all())
+
+    elif request.method == 'DELETE':
+        StatusHandlers.clear_all()
+        return return_api({})
 
 
 @api.route('/system/logs', methods=['GET'])

--- a/frontend/api.py
+++ b/frontend/api.py
@@ -14,7 +14,8 @@ from backend.base.definitions import (BlocklistReason, BlocklistReasonID,
                                       DownloadSource, FileMatch,
                                       KapowarrException, LibraryFilter,
                                       LibrarySorting, MonitorScheme,
-                                      SpecialVersion, StartType, VolumeData)
+                                      SpecialVersion, StartType,
+                                      StatusType, VolumeData)
 from backend.base.helpers import hash_credential
 from backend.base.logging import LOGGER, get_log_file_contents
 from backend.features.download_queue import (DownloadHandler,
@@ -295,10 +296,16 @@ def api_about():
 @auth
 def api_status_checks():
     if request.method == 'GET':
-        return return_api(StatusHandlers.get_all())
+        return return_api(StatusHandlers().get_all())
 
     elif request.method == 'DELETE':
-        StatusHandlers.clear_all()
+        status_type = extract_key(
+            request, 'type', check_existence=False
+        )
+        if status_type:
+            StatusHandlers().clear(StatusType(status_type))
+        else:
+            StatusHandlers().clear_all()
         return return_api({})
 
 

--- a/frontend/static/css/add_volume.css
+++ b/frontend/static/css/add_volume.css
@@ -68,6 +68,7 @@ main > div {
 #search-explain,
 #search-empty,
 #search-failed,
+#search-rate-limited,
 #search-blocked,
 #search-loading {
 	color: var(--text-color);

--- a/frontend/static/css/general.css
+++ b/frontend/static/css/general.css
@@ -302,9 +302,9 @@ nav svg {
 	height: 1.2rem;
 	padding: 0 .3rem;
 	margin-left: .3rem;
-	border-radius: .6rem;
-	background-color: var(--error-color);
-	color: var(--light-color);
+	border-radius: 2px;
+	background-color: var(--accent-color);
+	color: var(--nav-background-color);
 	font-size: .7rem;
 	font-weight: 700;
 }

--- a/frontend/static/css/general.css
+++ b/frontend/static/css/general.css
@@ -294,6 +294,21 @@ nav svg {
 	font-size: .8rem;
 }
 
+#system-issues-badge {
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
+	min-width: 1.2rem;
+	height: 1.2rem;
+	padding: 0 .3rem;
+	margin-left: .3rem;
+	border-radius: .6rem;
+	background-color: var(--error-color);
+	color: var(--light-color);
+	font-size: .7rem;
+	font-weight: 700;
+}
+
 /*  */
 /* Main window */
 /*  */

--- a/frontend/static/css/library_import.css
+++ b/frontend/static/css/library_import.css
@@ -3,6 +3,15 @@ main {
 	color: var(--text-color);
 }
 
+#rate-limit-banner {
+	padding: .7rem 1rem;
+	margin-bottom: 1rem;
+	border-radius: 4px;
+	background-color: var(--error-color);
+	color: var(--light-color);
+	font-weight: 500;
+}
+
 #start-window {
 	display: flex;
 	flex-direction: column;

--- a/frontend/static/css/library_import.css
+++ b/frontend/static/css/library_import.css
@@ -5,11 +5,13 @@ main {
 
 #rate-limit-banner {
 	padding: .7rem 1rem;
-	margin-bottom: 1rem;
+	margin-inline: auto;
+	width: fit-content;
 	border-radius: 4px;
 	background-color: var(--error-color);
 	color: var(--light-color);
 	font-weight: 500;
+	text-align: center;
 }
 
 #start-window {

--- a/frontend/static/css/status.css
+++ b/frontend/static/css/status.css
@@ -36,6 +36,24 @@ section:not(:first-of-type) h2 {
 	font-weight: 700;
 }
 
+#status-checks-table {
+	width: 100%;
+	min-width: 31rem;
+}
+
+#status-checks-table :where(th, td) {
+	padding: .3rem .5rem;
+}
+
+#status-checks-table th {
+	text-align: left;
+	font-weight: 500;
+}
+
+#status-checks-ok {
+	padding: .5rem;
+}
+
 #about-table {
 	width: 100%;
 	min-width: 31rem;

--- a/frontend/static/css/status.css
+++ b/frontend/static/css/status.css
@@ -36,18 +36,24 @@ section:not(:first-of-type) h2 {
 	font-weight: 700;
 }
 
-#status-checks-table {
-	width: 100%;
-	min-width: 31rem;
+.status-check-item {
+	display: flex;
+	align-items: center;
+	gap: 1rem;
+	padding: .5rem;
 }
 
-#status-checks-table :where(th, td) {
-	padding: .3rem .5rem;
+.status-check-item p {
+	color: var(--error-color);
 }
 
-#status-checks-table th {
-	text-align: left;
-	font-weight: 500;
+.status-check-item button {
+	padding: .3rem .7rem;
+	border-radius: 4px;
+	background-color: var(--accent-color);
+	color: var(--nav-background-color);
+	font-weight: 700;
+	font-size: .8rem;
 }
 
 #status-checks-ok {

--- a/frontend/static/js/add_volume.js
+++ b/frontend/static/js/add_volume.js
@@ -11,6 +11,7 @@ const SearchEls = {
 	msgs: {
 		blocked: document.querySelector('#search-blocked'),
 		failed: document.querySelector('#search-failed'),
+		rate_limited: document.querySelector('#search-rate-limited'),
 		empty: document.querySelector('#search-empty'),
 		explain: document.querySelector('#search-explain'),
 		loading: document.querySelector('#search-loading')
@@ -214,6 +215,7 @@ function search(reset_url_params=true) {
 		SearchEls.msgs.empty,
 		SearchEls.msgs.explain,
 		SearchEls.msgs.failed,
+		SearchEls.msgs.rate_limited,
 		SearchEls.search_results
 	], [
 		SearchEls.msgs.loading
@@ -237,6 +239,8 @@ function search(reset_url_params=true) {
 		.catch(e => {
 			if (e.status === 400)
 				hide([SearchEls.msgs.loading], [SearchEls.msgs.failed]);
+			else if (e.status === 509)
+				hide([SearchEls.msgs.loading], [SearchEls.msgs.rate_limited]);
 			else
 				console.log(e);
 		});
@@ -247,7 +251,8 @@ function clearSearch(e) {
 	hide([
 		SearchEls.search_results,
 		SearchEls.msgs.empty,
-		SearchEls.msgs.failed
+		SearchEls.msgs.failed,
+		SearchEls.msgs.rate_limited
 	], [
 		SearchEls.msgs.explain
 	]);
@@ -376,6 +381,9 @@ function fillRootFolderInput(api_key) {
 };
 
 function showAddWindow(comicvine_id, api_key) {
+	SearchEls.window.submit.innerText = 'Add Volume';
+	SearchEls.window.submit.style.color = '';
+
 	const volume_data = document.querySelector(
 		`button[data-comicvine_id="${comicvine_id}"]`
 	).dataset;
@@ -452,9 +460,11 @@ function addVolume() {
 		.catch(e => {
 			if (e.status === 509) {
 				SearchEls.window.submit.innerText = 'ComicVine API rate limit reached';
+				SearchEls.window.submit.style.color = 'var(--error-color)';
 				showWindow("add-window");
 			} else if (e.status === 400) {
 				SearchEls.window.submit.innerText = 'Volume folder is parent or child of other volume folder';
+				SearchEls.window.submit.style.color = 'var(--error-color)';
 				showWindow("add-window");
 			} else
 				console.log(e);

--- a/frontend/static/js/general.js
+++ b/frontend/static/js/general.js
@@ -228,6 +228,28 @@ function handleTaskRemoved(data) {
 		unspinButton(task_string);
 };
 
+function updateBadge(count) {
+	const badge = document.querySelector('#system-issues-badge');
+	if (!badge) return;
+	badge.innerText = count;
+	if (count > 0)
+		badge.classList.remove('hidden');
+	else
+		badge.classList.add('hidden');
+};
+
+function handleStatusCount(data) {
+	updateBadge(data.count);
+};
+
+function initStatusBadge(api_key) {
+	fetchAPI('/system/status/checks', api_key)
+	.then(json => {
+		updateBadge(json.result.length);
+	})
+	.catch(e => console.log(e));
+};
+
 function connectToWebSocket(api_key) {
 	const socket = io({
 		path: `${url_base}/api/socket.io`,
@@ -243,6 +265,7 @@ function connectToWebSocket(api_key) {
 	socket.on('task_added', handleTaskAdded);
 	socket.on('task_ended', handleTaskRemoved);
 	socket.on('task_status', data => setTaskMessage(data.message));
+	socket.on('status_count', handleStatusCount);
 	socket.connect();
 	return socket;
 };
@@ -350,6 +373,7 @@ usingApiKey()
 .then(api_key => {
 	setTimeout(() => fillTaskQueue(api_key), 200);
 	socket = connectToWebSocket(api_key);
+	initStatusBadge(api_key);
 });
 
 setupLocalStorage();

--- a/frontend/static/js/library_import.js
+++ b/frontend/static/js/library_import.js
@@ -86,9 +86,7 @@ function loadProposal(api_key) {
 				.then(checks => {
 					const search_limited = checks.result.some(
 						st => st.type === 'cv_rate_limit'
-							&& st.subtypes.some(
-								s => s.name === 'search_volumes'
-							)
+							&& st.subtypes.includes('search_volumes')
 					);
 					if (search_limited)
 						hide([], [LIEls.rate_limit_banner]);

--- a/frontend/static/js/library_import.js
+++ b/frontend/static/js/library_import.js
@@ -10,6 +10,7 @@ const LIEls = {
 		loading: document.querySelector('#loading-window'),
 		no_cv: document.querySelector('#no-cv-window')
 	},
+	rate_limit_banner: document.querySelector('#rate-limit-banner'),
 	proposal_list: document.querySelector('.proposal-list'),
 	select_all: document.querySelector('#selectall-input'),
 	search: {
@@ -40,7 +41,8 @@ function loadProposal(api_key) {
 		params.folder_filter = encodeURIComponent(ffi.value);
 
 	hide(
-		[LIEls.views.start, document.querySelector('#folder-filter-error')],
+		[LIEls.views.start, document.querySelector('#folder-filter-error'),
+		 LIEls.rate_limit_banner],
 		[LIEls.views.loading]
 	);
 
@@ -73,23 +75,45 @@ function loadProposal(api_key) {
 			LIEls.proposal_list.appendChild(entry);
 		});
 
-		if (json.result.length > 0)
+		if (json.result.length > 0) {
 			hide([LIEls.views.loading], [LIEls.views.list]);
-		else
+
+			const has_empty_matches = json.result.some(
+				r => r.cv.id === null
+			);
+			if (has_empty_matches) {
+				fetchAPI('/system/status/checks', api_key)
+				.then(checks => {
+					const search_limited = checks.result.some(
+						st => st.type === 'cv_rate_limit'
+							&& st.subtypes.some(
+								s => s.name === 'search_volumes'
+							)
+					);
+					if (search_limited)
+						hide([], [LIEls.rate_limit_banner]);
+				});
+			};
+		} else
 			hide([LIEls.views.loading], [LIEls.views.no_result]);
 	})
 	.catch(e => {
-		e.json().then(j => {
-			if (j.error === 'InvalidComicVineApiKey')
-				hide([LIEls.views.loading], [LIEls.views.no_cv]);
-			else if (j.error === 'InvalidKeyValue')
-				hide(
-					[LIEls.views.loading],
-					[LIEls.views.start, document.querySelector('#folder-filter-error')]
-				);
-			else
-				console.log(j);
-		});
+		if (e.status === 509) {
+			hide([LIEls.views.loading], [LIEls.views.start]);
+			hide([], [LIEls.rate_limit_banner]);
+		} else {
+			e.json().then(j => {
+				if (j.error === 'InvalidComicVineApiKey')
+					hide([LIEls.views.loading], [LIEls.views.no_cv]);
+				else if (j.error === 'InvalidKeyValue')
+					hide(
+						[LIEls.views.loading],
+						[LIEls.views.start, document.querySelector('#folder-filter-error')]
+					);
+				else
+					console.log(j);
+			});
+		};
 	});
 };
 

--- a/frontend/static/js/status.js
+++ b/frontend/static/js/status.js
@@ -6,6 +6,11 @@ const StatEls = {
 	data_folder: document.querySelector('#data-folder'),
 	os: document.querySelector('#os'),
 	runs_64bit: document.querySelector('#runs-64bit'),
+	status_checks: {
+		table: document.querySelector('#status-checks-table'),
+		body: document.querySelector('#status-checks-body'),
+		ok: document.querySelector('#status-checks-ok')
+	},
 	buttons: {
 		copy: document.querySelector('#copy-about'),
 		restart: document.querySelector('#restart-button'),
@@ -26,10 +31,53 @@ const about_table = `
 
 `;
 
+function loadStatusChecks(api_key) {
+	fetchAPI('/system/status/checks', api_key)
+	.then(json => {
+		StatEls.status_checks.body.innerHTML = '';
+		if (json.result.length === 0) {
+			hide([StatEls.status_checks.table],
+				[StatEls.status_checks.ok]);
+		} else {
+			hide([StatEls.status_checks.ok],
+				[StatEls.status_checks.table]);
+			json.result.forEach(status_type => {
+				status_type.subtypes.forEach(sub => {
+					const row = document.createElement('tr');
+
+					const source = document.createElement('td');
+					source.innerText = status_type.source;
+
+					const category = document.createElement('td');
+					category.innerText = sub.label;
+
+					const status = document.createElement('td');
+					status.innerText = status_type.description;
+					status.style.color = 'var(--error-color)';
+
+					const since = document.createElement('td');
+					since.innerText = new Date(
+						sub.since * 1000
+					).toLocaleString();
+
+					row.appendChild(source);
+					row.appendChild(category);
+					row.appendChild(status);
+					row.appendChild(since);
+					StatEls.status_checks.body.appendChild(row);
+				});
+			});
+		};
+	})
+	.catch(e => console.log(e));
+};
+
 // code run on load
 
 usingApiKey()
 .then(api_key => {
+	loadStatusChecks(api_key);
+
 	fetchAPI('/system/about', api_key)
 	.then(json => {
 		StatEls.version.innerText = json.result.version;

--- a/frontend/static/js/status.js
+++ b/frontend/static/js/status.js
@@ -7,8 +7,7 @@ const StatEls = {
 	os: document.querySelector('#os'),
 	runs_64bit: document.querySelector('#runs-64bit'),
 	status_checks: {
-		table: document.querySelector('#status-checks-table'),
-		body: document.querySelector('#status-checks-body'),
+		list: document.querySelector('#status-checks-list'),
 		ok: document.querySelector('#status-checks-ok')
 	},
 	buttons: {
@@ -31,41 +30,52 @@ const about_table = `
 
 `;
 
+const subtypeLabels = {
+	'search_volumes': 'Searching volumes',
+	'fetch_volume': 'Fetching volume metadata',
+	'fetch_issues': 'Fetching issue metadata'
+};
+
+const statusDescriptions = {
+	'cv_rate_limit': 'ComicVine rate limit reached'
+};
+
 function loadStatusChecks(api_key) {
 	fetchAPI('/system/status/checks', api_key)
 	.then(json => {
-		StatEls.status_checks.body.innerHTML = '';
+		StatEls.status_checks.list.innerHTML = '';
 		if (json.result.length === 0) {
-			hide([StatEls.status_checks.table],
+			hide([StatEls.status_checks.list],
 				[StatEls.status_checks.ok]);
 		} else {
 			hide([StatEls.status_checks.ok],
-				[StatEls.status_checks.table]);
-			json.result.forEach(status_type => {
-				status_type.subtypes.forEach(sub => {
-					const row = document.createElement('tr');
+				[StatEls.status_checks.list]);
+			json.result.forEach(entry => {
+				const item = document.createElement('div');
+				item.classList.add('status-check-item');
 
-					const source = document.createElement('td');
-					source.innerText = status_type.source;
+				const text = document.createElement('p');
+				const desc = statusDescriptions[entry.type]
+					|| entry.description;
+				const subs = entry.subtypes
+					.map(s => subtypeLabels[s] || s)
+					.join(', ');
+				text.innerText = `${desc}: ${subs}`;
 
-					const category = document.createElement('td');
-					category.innerText = sub.label;
+				const clearBtn = document.createElement('button');
+				clearBtn.innerText = 'Clear';
+				clearBtn.onclick = e => {
+					sendAPI(
+						'DELETE',
+						'/system/status/checks',
+						api_key,
+						{type: entry.type}
+					).then(() => loadStatusChecks(api_key));
+				};
 
-					const status = document.createElement('td');
-					status.innerText = status_type.description;
-					status.style.color = 'var(--error-color)';
-
-					const since = document.createElement('td');
-					since.innerText = new Date(
-						sub.since * 1000
-					).toLocaleString();
-
-					row.appendChild(source);
-					row.appendChild(category);
-					row.appendChild(status);
-					row.appendChild(since);
-					StatEls.status_checks.body.appendChild(row);
-				});
+				item.appendChild(text);
+				item.appendChild(clearBtn);
+				StatEls.status_checks.list.appendChild(item);
 			});
 		};
 	})

--- a/frontend/templates/add_volume.html
+++ b/frontend/templates/add_volume.html
@@ -143,6 +143,10 @@
 			<p>The Comic Vine api key is not set or is invalid</p>
 			<p>Please set a working Comic Vine api key at Settings -> General -> Comic Vine API</p>
 		</section>
+		<section id="search-rate-limited" class="hidden">
+			<p>ComicVine API rate limit reached</p>
+			<p>Please wait a while before searching again</p>
+		</section>
 		<section id="search-blocked" class="hidden">
 			<p>You can't add volumes before having added at least one root folder</p>
 			<p>A root folder can be added at Settings -> Media Management -> Root Folders</p>

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -136,6 +136,7 @@
 						<path fill="currentColor" d="M128 32C92.7 32 64 60.7 64 96V352h64V96H512V352h64V96c0-35.3-28.7-64-64-64H128zM19.2 384C8.6 384 0 392.6 0 403.2C0 445.6 34.4 480 76.8 480H563.2c42.4 0 76.8-34.4 76.8-76.8c0-10.6-8.6-19.2-19.2-19.2H19.2z"></path>
 					</svg>
 					System
+					<span id="system-issues-badge" class="hidden">0</span>
 				</a>
 				<div class="sub-nav">
 					<a

--- a/frontend/templates/library_import.html
+++ b/frontend/templates/library_import.html
@@ -134,10 +134,6 @@
 		<a href="{{url_base}}/settings/general#cv-input">Go to settings</a>
 	</div>
 	<div id="list-window" class="hidden">
-		<p id="rate-limit-banner" class="hidden">
-			Some matches may be missing or incorrect because the ComicVine API rate limit was reached.
-			Entries with empty Match columns were likely affected.
-		</p>
 		<div class="action-container">
 			<button class="cancel-button">Cancel</button>
 			<button
@@ -149,6 +145,10 @@
 				title="Add volumes, move files into automatically generated volume folder (named following the settings), rename files. If the volume is already added, move the file into volume folder and rename."
 			>Import and Rename</button>
 		</div>
+		<p id="rate-limit-banner" class="hidden">
+			Some matches may be missing because the ComicVine API rate limit was reached.
+			Entries with empty Match columns were likely affected.
+		</p>
 		<div class="table-container icon-text-color">
 			<table aria-label="File list">
 				<thead>

--- a/frontend/templates/library_import.html
+++ b/frontend/templates/library_import.html
@@ -134,6 +134,10 @@
 		<a href="{{url_base}}/settings/general#cv-input">Go to settings</a>
 	</div>
 	<div id="list-window" class="hidden">
+		<p id="rate-limit-banner" class="hidden">
+			Some matches may be missing or incorrect because the ComicVine API rate limit was reached.
+			Entries with empty Match columns were likely affected.
+		</p>
 		<div class="action-container">
 			<button class="cancel-button">Cancel</button>
 			<button

--- a/frontend/templates/status.html
+++ b/frontend/templates/status.html
@@ -13,18 +13,7 @@
 		<section aria-label="Status Checks">
 			<h2>Status Checks</h2>
 			<div class="container">
-				<table id="status-checks-table" class="hidden">
-					<thead>
-						<tr>
-							<th>Source</th>
-							<th>Category</th>
-							<th>Status</th>
-							<th>Since</th>
-						</tr>
-					</thead>
-					<tbody id="status-checks-body">
-					</tbody>
-				</table>
+				<div id="status-checks-list"></div>
 				<p id="status-checks-ok">All systems operational</p>
 			</div>
 		</section>

--- a/frontend/templates/status.html
+++ b/frontend/templates/status.html
@@ -10,6 +10,24 @@
 {% block main %}
 <main>
 	<div>
+		<section aria-label="Status Checks">
+			<h2>Status Checks</h2>
+			<div class="container">
+				<table id="status-checks-table" class="hidden">
+					<thead>
+						<tr>
+							<th>Source</th>
+							<th>Category</th>
+							<th>Status</th>
+							<th>Since</th>
+						</tr>
+					</thead>
+					<tbody id="status-checks-body">
+					</tbody>
+				</table>
+				<p id="status-checks-ok">All systems operational</p>
+			</div>
+		</section>
 		<section aria-label="About">
 			<h2>
 				<span>About</span>

--- a/tests/Tbackend/status.py
+++ b/tests/Tbackend/status.py
@@ -1,0 +1,15 @@
+import unittest
+
+from backend.base.definitions import StatusType
+from backend.internals.status import StatusHandlers
+
+
+class status_handler_registration(unittest.TestCase):
+    def test_all_status_types_have_handlers(self):
+        """Every StatusType enum value must have a registered handler."""
+        for status_type in StatusType:
+            self.assertIn(
+                status_type,
+                StatusHandlers.handlers,
+                f"StatusType.{status_type.name} has no registered handler"
+            )


### PR DESCRIPTION
## Summary
- Adds a general-purpose **StatusHandlers** framework modeled after
  StartTypeHandlers, with registered handlers, DB persistence, and
  per-handler expiry/display logic
- First handler: **CVRateLimitHandler** tracks per-resource ComicVine
  rate limits with one-hour expiry and clear-on-success
- Adds a **Status Checks** section to System > Status page
- Adds a **WebSocket-powered badge** (count-only) on the System nav link
- Fixes **Add Volume search** to show rate limit message on 509
- Hardens **Add Volume submit** error display with red text and reset
- Adds **rate limit banner** to Library Import when matches affected
- New `GET/DELETE /api/system/status/checks` endpoint
- New `status_count` WebSocket event
- New `status` DB table with migration (version 46)

Partial implementation of #209 (ComicVine rate limit portion), fixes #332

## Architecture

The status framework follows the StartTypeHandlers pattern:
- `StatusType` enum + `StatusHandler` ABC in `definitions.py`
- `StatusHandlers` registry class in `internals/status.py`
- Handlers register via `@StatusHandlers.register_handler(StatusType.X)`
- Adding a new status type (drive space, CloudFlare, Mega, etc.) requires
  only a new enum value and a decorated handler class

Status entries are persisted to a `status` table with `expires_at` for
automatic expiry. On startup, expired entries are cleaned up and active
entries are restored with timers for the remaining duration.

## Rate limit state management

ComicVine provides no metadata when rate limited (no headers, no reset
time, just status_code 107). State clears via two mechanisms:

1. **One-hour expiry timer** from first rejection. Does not reset on
   subsequent rejections.
2. **Clear on success** when a subsequent API call to the same resource
   succeeds.

Research suggests ComicVine uses a rolling 60-minute window rather than
a fixed clock-hour reset, based on the API dashboard countdown behavior
and how other CV consumers (comictagger, Simyan) implement it.

## Known limitations

- `fetch_volumes()` (bulk metadata, used by Update All) silently swallows
  rate limits via a default parameter. Fixing this would require modifying
  the core `__call_api` method. Note: `__search_query` had the same issue
  and is fixed in this PR.

## Test plan
- [ ] Search on Add Volume with rate limit: verify message appears
- [ ] Add volume with rate limit: verify red error text, resets on reopen
- [ ] Library Import with rate limit: verify banner above results
- [ ] System > Status: verify table shows active limits with timestamps
- [ ] System > Status: verify "All systems operational" when clear
- [ ] Navbar badge: verify count updates via WebSocket
- [ ] Restart container: verify status persists from DB
- [ ] Restart after expiry: verify expired entries are cleaned up
- [ ] Wait for expiry timer: verify status auto-clears
- [ ] Successful API call after rate limit: verify status clears
- [ ] GET /api/system/status/checks: returns active statuses
- [ ] DELETE /api/system/status/checks: clears all