### PR TITLE
fix: FlareSolverr reliability - maxTimeout, null body guard, longer HTTP timeout

### DIFF
--- a/backend/base/definitions.py
+++ b/backend/base/definitions.py
@@ -116,10 +116,13 @@ class Constants:
     "The base URL of the Pixeldrain API"
 
     FS_API_BASE = "/v1"
-    "The base endpoint of the FlareSolverr API"
+    """The base endpoint of the FlareSolverr API"""
+
+    FS_MAX_TIMEOUT = 300000  # milliseconds (5 minutes)
+    """Max time FlareSolverr waits for a page to fully load"""
 
     MAX_CONCURRENT_FS_SESSIONS = 2
-    "The maximum amount of FlareSolverr browser sessions that can concurrently run"
+    """The maximum amount of FlareSolverr browser sessions that can concurrently run"""
 
     CF_CHALLENGE_HEADER = ("cf-mitigated", "challenge")
     """

--- a/backend/base/helpers.py
+++ b/backend/base/helpers.py
@@ -1019,9 +1019,16 @@ class Session(RSession):
             fs_result = self.fs.handle_cf_block(result.url, result.headers)
 
             if fs_result:
+                response_body = fs_result.get("response")
+                if response_body is None:
+                    LOGGER.warning(
+                        "FlareSolverr returned null response body for %s",
+                        result.url
+                    )
+                    return result
                 result.url = fs_result["url"]
                 result.status_code = fs_result["status"]
-                result._content = fs_result["response"].encode("utf-8")
+                result._content = response_body.encode("utf-8")
                 result.headers = CaseInsensitiveDict(fs_result["headers"])
 
         if 400 <= result.status_code < 500:
@@ -1109,10 +1116,17 @@ class AsyncSession(ClientSession):
                 )
 
                 if fs_result:
+                    response_body = fs_result.get("response")
+                    if response_body is None:
+                        LOGGER.warning(
+                            "FlareSolverr returned null response body for %s",
+                            response.url
+                        )
+                        return response
                     response._url = URL(fs_result["url"])
                     response._real_url = URL(fs_result["url"])
                     response.status = fs_result["status"]
-                    response._body = fs_result["response"].encode("utf-8")
+                    response._body = response_body.encode("utf-8")
                     response._headers = CIMultiDictProxy(CIMultiDict(
                         fs_result["headers"]
                     ))

--- a/backend/implementations/flaresolverr.py
+++ b/backend/implementations/flaresolverr.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 from asyncio import Semaphore
 from typing import TYPE_CHECKING, Any, Dict, Mapping, Tuple, Union
 
-from requests import RequestException
+from requests import RequestException, Session as _SyncSession
 
 from backend.base.definitions import Constants, ProxyType
 from backend.base.helpers import Session
 from backend.base.logging import LOGGER
 from backend.internals.settings import Settings
+
+# FlareSolverr requests can take a long time (page load + CF solve),
+# so we use a longer timeout than the default REQUEST_TIMEOUT.
+FS_HTTP_TIMEOUT = (Constants.FS_MAX_TIMEOUT // 1000) + 30  # seconds
 
 if TYPE_CHECKING:
     from backend.base.helpers import AsyncSession
@@ -51,7 +55,8 @@ class FlareSolverr:
         return session.post(
             base_url + Constants.FS_API_BASE,
             json=data,
-            headers={'Content-Type': 'application/json'}
+            headers={'Content-Type': 'application/json'},
+            timeout=FS_HTTP_TIMEOUT
         ).json()
 
     @staticmethod
@@ -176,7 +181,8 @@ class FlareSolverr:
                 {
                     'cmd': 'request.get',
                     'session': session_id,
-                    'url': url
+                    'url': url,
+                    'maxTimeout': Constants.FS_MAX_TIMEOUT
                 }
             )["solution"]
 
@@ -257,7 +263,8 @@ class FlareSolverr:
                 {
                     'cmd': 'request.get',
                     'session': session_id,
-                    'url': url
+                    'url': url,
+                    'maxTimeout': Constants.FS_MAX_TIMEOUT
                 }
             ))["solution"]
 


### PR DESCRIPTION
## Summary

Fixes 3 FlareSolverr reliability issues reported in #335:

1. **Missing `maxTimeout`** - FlareSolverr defaults to 60s timeout, frequently insufficient for Cloudflare challenges on getcomics.org
2. **Short HTTP timeout** - The HTTP call to FlareSolverr used 30s `REQUEST_TIMEOUT`, but FS itself needs up to 5 minutes
3. **Null response body crash** - `fs_result["response"].encode("utf-8")` fails with `AttributeError` when FS returns null response

## Changes

- `backend/base/definitions.py`: Add `FS_MAX_TIMEOUT = 300000` constant (5 min)
- `backend/implementations/flaresolverr.py`: Add `maxTimeout` to request.get payloads, pass longer HTTP timeout to sync session
- `backend/base/helpers.py`: Guard `fs_result["response"]` against `None` in both sync (`Session`) and async (`AsyncSession`) paths

Closes #335