### PR TITLE
Don't blocklist rate-limited GetComics download links in __purify_link

### DIFF
--- a/backend/implementations/getcomics.py
+++ b/backend/implementations/getcomics.py
@@ -483,6 +483,12 @@ async def __purify_link(
 
     async with AsyncSession() as session:
         r = await session.get(link)
+    if r.status == 429:
+        # GetComics rate-limited the download-link resolution. Treat as a
+        # rate limit (not a broken link) so it isn't blocklisted. See #342.
+        raise EnqueuingDownloadFailure(
+            EnqueuingDownloadFailureReason.LINK_RATE_LIMITED
+        )
     if not r.ok:
         raise DownloadLinkBroken(link)
     url = str(r.real_url)


### PR DESCRIPTION
Fixes #355.

A 429 during download-link resolution in `__purify_link` was raised as `DownloadLinkBroken`, which blocklists the link permanently. Newly added multi-issue volumes trigger a burst of concurrent `/dls/…` requests that GetComics rate-limits, so good links get blocklisted and re-search never retries them.

This is the same class of bug as #342, which was fixed for the article-page fetch in `load_data`. That fix missed the download-link resolution path. This handles 429 there the same way:

```python
if r.status == 429:
    raise EnqueuingDownloadFailure(
        EnqueuingDownloadFailureReason.LINK_RATE_LIMITED
    )
```

`EnqueuingDownloadFailure(LINK_RATE_LIMITED)` propagates through `create_downloads` up to `DownloadHandler`/`add`, which (per the #342 fix) skips blocklisting for that reason. Chosen for consistency with the existing #342 handling rather than mapping to a per-service rate-limit — happy to switch to `DownloadServiceRateLimitReached` + `limit_reached` if you'd prefer the "try the remaining mirrors first" behaviour.

### Testing
- `python -m py_compile` on the changed module.
- Verified the exception propagation path by inspection: `__purify_link` → `__purify_download_group` (not caught by its `DownloadLinkBroken`/`ClientError` handlers) → `gather` in `create_downloads` → `add()`'s `EnqueuingDownloadFailure` handler, which does not blocklist `LINK_RATE_LIMITED`.