### PR TITLE
Retry rate limited requests instead of failing on them

### DIFF
--- a/backend/base/definitions.py
+++ b/backend/base/definitions.py
@@ -107,6 +107,14 @@ class Constants:
     )
     "The HTTP status codes for which a retry should be done"
 
+    STATUS_RATELIMIT_RETRIES = (
+        429, # Too Many Requests
+    )
+    "The HTTP status codes for which a retry should be done after waiting"
+
+    MAX_RATELIMIT_WAIT = 30 # seconds
+    "The maximum amount of seconds to wait in-between rate limited retries"
+
     PROXY_TEST_URL = "https://httpbin.org/ip"
 
     CV_SITE_URL = "https://comicvine.gamespot.com"

--- a/backend/base/helpers.py
+++ b/backend/base/helpers.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from asyncio import sleep
 from base64 import urlsafe_b64encode
 from datetime import datetime
+from email.utils import parsedate_to_datetime
 from functools import lru_cache
 from hashlib import pbkdf2_hmac
 from multiprocessing.pool import Pool
@@ -18,6 +19,7 @@ from re import compile
 from subprocess import run
 from sys import base_exec_prefix, executable, maxsize, platform, version_info
 from threading import current_thread
+from time import sleep as sync_sleep
 from typing import (TYPE_CHECKING, Any, Callable, Collection, Dict, Iterable,
                     Iterator, List, Mapping, Sequence, Tuple, Union)
 from unicodedata import normalize
@@ -959,6 +961,55 @@ def retry(
         )
 
 
+def get_ratelimit_wait(
+    headers: Mapping[str, str],
+    round: int
+) -> float:
+    """Determine how long to wait before retrying a rate limited request. The
+    `Retry-After` header of the response is honoured if it's present and
+    usable, in both the "delay in seconds" and the "HTTP date" notation.
+    Otherwise the standard exponential backoff is applied.
+
+    ```
+    >>> get_ratelimit_wait({"Retry-After": "5"}, 1)
+    5.0
+    >>> get_ratelimit_wait({}, 3)
+    4.0
+    ```
+
+    Args:
+        headers (Mapping[str, str]): The headers of the rate limited response.
+
+        round (int): The retry round that was just done, starting at 1.
+
+    Returns:
+        float: The amount of seconds to wait, never negative and never more
+            than `Constants.MAX_RATELIMIT_WAIT`.
+    """
+    wait = None
+    retry_after = headers.get("Retry-After")
+
+    if retry_after:
+        try:
+            wait = float(retry_after)
+
+        except ValueError:
+            try:
+                wait = (
+                    parsedate_to_datetime(retry_after).timestamp()
+                    - datetime.now().timestamp()
+                )
+            except (TypeError, ValueError, OverflowError):
+                wait = None
+
+    if wait is None:
+        wait = float(
+            Constants.BACKOFF_FACTOR_RETRIES * (2 ** (round - 1))
+        )
+
+    return max(0.0, min(wait, float(Constants.MAX_RATELIMIT_WAIT)))
+
+
 class Session(RSession):
     """
     Inherits from `requests.Session`. Adds retries, sets user agent and handles
@@ -1006,14 +1057,36 @@ class Session(RSession):
         self.headers.update({"User-Agent": ua})
         self.cookies.update(cf_cookies)
 
-        result = super().request(
-            method, url, params, data, headers,
-            cookies, files, auth,
-            timeout, allow_redirects,
-            proxies, hooks,
-            stream, verify,
-            cert, json
-        )
+        for round in range(1, Constants.TOTAL_RETRIES + 1):
+            result = super().request(
+                method, url, params, data, headers,
+                cookies, files, auth,
+                timeout, allow_redirects,
+                proxies, hooks,
+                stream, verify,
+                cert, json
+            )
+
+            if (
+                result.status_code not in Constants.STATUS_RATELIMIT_RETRIES
+                or round == Constants.TOTAL_RETRIES
+            ):
+                # Not rate limited, or out of retries. In the latter case, the
+                # response is returned instead of raised, so that callers can
+                # tell a rate limit apart from a broken request.
+                break
+
+            wait = get_ratelimit_wait(result.headers, round)
+            LOGGER.warning(
+                "%s request to %s is rate limited. "
+                "Retrying in %.1fs for round %d...",
+                method, url, wait, round + 1
+            )
+            # The body of the response is of no use and is never read when
+            # streaming, which would keep the connection checked out of the
+            # pool for the duration of the wait and the rounds after it.
+            result.close()
+            sync_sleep(wait)
 
         if result.status_code == 403:
             fs_result = self.fs.handle_cf_block(result.url, result.headers)
@@ -1102,6 +1175,23 @@ class AsyncSession(ClientSession):
                     Constants.BACKOFF_FACTOR_RETRIES *
                     (2 ** (round - 1))
                 )
+                continue
+
+            if (
+                response.status in Constants.STATUS_RATELIMIT_RETRIES
+                and round < Constants.TOTAL_RETRIES
+            ):
+                wait = get_ratelimit_wait(response.headers, round)
+                LOGGER.warning(
+                    "%s request to %s is rate limited. "
+                    "Retrying in %.1fs for round %d...",
+                    method, url, wait, round + 1
+                )
+                # Give the connection back before waiting on it, instead of
+                # holding it for the duration of the wait and the rounds
+                # after it.
+                response.release()
+                await sleep(wait)
                 continue
 
             if response.status == 403:

--- a/tests/Tbackend/base/helpers.py
+++ b/tests/Tbackend/base/helpers.py
@@ -1,0 +1,200 @@
+import unittest
+from asyncio import get_event_loop_policy
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+from backend.base.definitions import Constants
+from backend.base.helpers import AsyncSession, Session, get_ratelimit_wait
+
+
+class ratelimit_wait(unittest.TestCase):
+    def test_retry_after_in_seconds_is_honoured(self):
+        self.assertEqual(get_ratelimit_wait({"Retry-After": "5"}, 1), 5.0)
+
+    def test_retry_after_of_zero_is_honoured(self):
+        self.assertEqual(get_ratelimit_wait({"Retry-After": "0"}, 3), 0.0)
+
+    def test_retry_after_is_capped(self):
+        self.assertEqual(
+            get_ratelimit_wait({"Retry-After": "3600"}, 1),
+            float(Constants.MAX_RATELIMIT_WAIT)
+        )
+
+    def test_retry_after_in_the_past_is_not_negative(self):
+        self.assertEqual(
+            get_ratelimit_wait(
+                {"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}, 1
+            ),
+            0.0
+        )
+
+    def test_unusable_retry_after_falls_back_to_backoff(self):
+        self.assertEqual(
+            get_ratelimit_wait({"Retry-After": "soon"}, 1),
+            float(Constants.BACKOFF_FACTOR_RETRIES)
+        )
+
+    def test_missing_retry_after_backs_off_exponentially(self):
+        self.assertEqual(
+            [get_ratelimit_wait({}, round) for round in (1, 2, 3, 4)],
+            [
+                float(Constants.BACKOFF_FACTOR_RETRIES * 2 ** (round - 1))
+                for round in (1, 2, 3, 4)
+            ]
+        )
+
+
+class FakeResponse:
+    def __init__(self, status: int) -> None:
+        self.status = status
+        self.headers: Dict[str, str] = {"Retry-After": "0"}
+        self.url = "https://example.com"
+        self.released = False
+
+    async def text(self) -> str:
+        return ""
+
+    def release(self) -> None:
+        self.released = True
+
+
+class FakeRequest:
+    method = "GET"
+    url = "https://example.com"
+
+
+class FakeSyncResponse:
+    def __init__(self, status: int) -> None:
+        self.status_code = status
+        self.headers: Dict[str, str] = {"Retry-After": "0"}
+        self.url = "https://example.com"
+        self.request = FakeRequest()
+        self.text = ""
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeFlareSolverr:
+    def get_ua_cookies(self, url: str):
+        return Constants.DEFAULT_USERAGENT, {}
+
+    def handle_cf_block(self, url: str, headers):
+        return None
+
+
+class async_session_ratelimit_retries(unittest.TestCase):
+    """A rate limited response has to be retried, and only handed back to the
+    caller once the retries are exhausted. Otherwise a burst of requests to a
+    single source makes every request but the first few fail permanently.
+    """
+
+    def run_session(self, statuses: List[int]) -> Any:
+        self.responses = [FakeResponse(status) for status in statuses]
+        responses = self.responses
+        calls: List[Any] = []
+
+        async def fake_request(self, *args, **kwargs):
+            calls.append(args)
+            return responses[len(calls) - 1]
+
+        async def main():
+            with patch(
+                "backend.implementations.flaresolverr.FlareSolverr",
+                FakeFlareSolverr
+            ), patch(
+                "aiohttp.ClientSession._request", fake_request
+            ):
+                async with AsyncSession() as session:
+                    return await session._request(
+                        "GET", "https://example.com"
+                    ), len(calls)
+
+        loop = get_event_loop_policy().new_event_loop()
+        try:
+            return loop.run_until_complete(main())
+        finally:
+            loop.close()
+
+    def test_rate_limited_request_is_retried(self):
+        response, calls = self.run_session([429, 429, 200])
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(calls, 3)
+
+    def test_successful_request_is_not_retried(self):
+        response, calls = self.run_session([200])
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(calls, 1)
+
+    def test_exhausted_retries_return_the_rate_limited_response(self):
+        response, calls = self.run_session(
+            [429] * Constants.TOTAL_RETRIES
+        )
+
+        self.assertEqual(response.status, 429)
+        self.assertEqual(calls, Constants.TOTAL_RETRIES)
+
+    def test_abandoned_responses_are_released(self):
+        self.run_session([429, 429, 200])
+
+        self.assertEqual(
+            [r.released for r in self.responses],
+            [True, True, False]
+        )
+
+
+class session_ratelimit_retries(unittest.TestCase):
+    """The same for the sync session, which is what fetches the web pages and
+    starts the file downloads.
+    """
+
+    def run_session(self, statuses: List[int]) -> Any:
+        self.responses = [FakeSyncResponse(status) for status in statuses]
+        responses = self.responses
+        calls: List[Any] = []
+
+        def fake_request(self, *args, **kwargs):
+            calls.append(args)
+            return responses[len(calls) - 1]
+
+        with patch(
+            "backend.implementations.flaresolverr.FlareSolverr",
+            FakeFlareSolverr
+        ), patch(
+            "requests.Session.request", fake_request
+        ):
+            session = Session()
+            return session.request(
+                "GET", "https://example.com", stream=True
+            ), len(calls)
+
+    def test_rate_limited_request_is_retried(self):
+        response, calls = self.run_session([429, 429, 200])
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(calls, 3)
+
+    def test_successful_request_is_not_retried(self):
+        response, calls = self.run_session([200])
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(calls, 1)
+
+    def test_exhausted_retries_return_the_rate_limited_response(self):
+        response, calls = self.run_session(
+            [429] * Constants.TOTAL_RETRIES
+        )
+
+        self.assertEqual(response.status_code, 429)
+        self.assertEqual(calls, Constants.TOTAL_RETRIES)
+
+    def test_abandoned_responses_are_closed(self):
+        self.run_session([429, 429, 200])
+
+        self.assertEqual(
+            [r.closed for r in self.responses],
+            [True, True, False]
+        )


### PR DESCRIPTION
Contributing request: #360.

HTTP 429 was not retried by either session class. `STATUS_FORCELIST_RETRIES`
only holds server errors, so in `AsyncSession._request` a 429 never raises
`ClientError`, falls through to the generic 4xx warning and is handed back as a
final response. `Session` inherits the same gap through its urllib3 `Retry`.

For GetComics that means a burst of concurrent requests — a search fetching
several article pages, or `search_all` adding a batch of downloads in the same
second — gets 429s that are treated as permanent failures. The issues become
`LINK_RATE_LIMITED` and are dropped: not queued, not blocklisted, not in
history. Nothing retries them and nothing records the attempt.

## What changed

- `Constants.STATUS_RATELIMIT_RETRIES = (429,)` and
  `Constants.MAX_RATELIMIT_WAIT = 30`.
- `get_ratelimit_wait()` in `helpers.py` works out how long to wait: the
  `Retry-After` header when present and usable (both the seconds and the
  HTTP-date notation), otherwise the existing exponential backoff. Never
  negative, never above `MAX_RATELIMIT_WAIT`.
- `Session.request` and `AsyncSession._request` retry a rate limited response
  up to `TOTAL_RETRIES` times.

When the retries run out the 429 response is **returned**, not raised, so the
existing handling in the GetComics prepper — `DownloadServiceRateLimitReached`
in `__purify_link` and `LINK_RATE_LIMITED` in `__fetch_page` — still sees a 429
and behaves exactly as before. Nothing else in the codebase changes behaviour.

## Verification

On my instance, a single isolated `curl` to a GetComics article returned 200 in
0.22s with the Kapowarr user agent, while Kapowarr itself logged 178 429s in an
hour — the rate limiting was self-inflicted by the burst, not an IP block.

New tests in `tests/Tbackend/base/helpers.py` cover the wait calculation and the
retry loop (retried, not retried on success, and the exhausted case returning
the 429). Full suite passes; `mypy --explicit-package-bases`, `isort` and
`autopep8` are clean.
