### PR TITLE
Don't swallow a series name that starts with a number

### DIFF
--- a/backend/base/file_extraction.py
+++ b/backend/base/file_extraction.py
@@ -381,7 +381,7 @@ def extract_filename_data(
     all_year_folderpos = [(10_000, 0)]
     volume_pos, volume_end = 10_000, 0
     volume_folderpos, volume_folderend = 10_000, 0
-    issue_pos, issue_folderpos = 10_000, 10_000
+    issue_pos, issue_end, issue_folderpos = 10_000, 0, 10_000
     special_pos, special_end = 10_000, 0
 
     # Process folder if file is metadata file, as metadata filename contains
@@ -527,6 +527,7 @@ def extract_filename_data(
             ):
                 issue_number = extracted_number
                 issue_pos = result_start
+                issue_end = result_end
                 break
 
     else:
@@ -580,6 +581,25 @@ def extract_filename_data(
             # Series name is assumed to be the upper foldername
             series = strip_filename_regex.sub('', upper_foldername)
     series = series_regex.sub('', series.replace('-', ' ').replace('_', ' '))
+
+    if (
+        not series
+        and issue_pos == 0
+        and not is_image_file
+        and not clean_filename[issue_end:].lstrip().startswith('-')
+    ):
+        # The issue number was found at the very start of the filename, there
+        # is no folder to take the series name from, and the number isn't
+        # separated from the rest by a dash (as in "5 - Title"). So there is
+        # nothing left that could be the series, meaning the number is not an
+        # issue number at all but (the start of) a series name that happens to
+        # begin with a number. E.g. "2000AD" is a series, not issue 2000.
+        series = series_regex.sub(
+            '', clean_filename.replace('-', ' ').replace('_', ' ')
+        )
+        issue_number = None
+        if not special_version:
+            special_version = SpecialVersion.TPB.value
 
     # Format output
     if issue_number is not None:

--- a/tests/Tbackend/base/file_extraction.py
+++ b/tests/Tbackend/base/file_extraction.py
@@ -332,4 +332,29 @@ class extract_filename_data(unittest.TestCase):
                 {'series': 'Iron Man', 'year': 2012, 'volume_number': 2, 'special_version': 'metadata', 'issue_number': 5.0, 'annual': False}
         }
         self.run_cases(cases)
+
+    def test_numeric_series_name(self):
+        cases = {
+            '2000AD':
+                {'series': '2000AD', 'year': None, 'volume_number': 1, 'special_version': 'tpb', 'issue_number': None, 'annual': False},
+
+            '2000 AD':
+                {'series': '2000 AD', 'year': None, 'volume_number': 1, 'special_version': 'tpb', 'issue_number': None, 'annual': False},
+
+            '2000AD (2026)':
+                {'series': '2000AD', 'year': 2026, 'volume_number': 1, 'special_version': 'tpb', 'issue_number': None, 'annual': False},
+
+            '52':
+                {'series': '52', 'year': None, 'volume_number': 1, 'special_version': 'tpb', 'issue_number': None, 'annual': False},
+
+            '2000AD #2493 (2026)':
+                {'series': '2000AD', 'year': 2026, 'volume_number': 1, 'special_version': None, 'issue_number': 2493.0, 'annual': False},
+
+            '52 #10 (2007)':
+                {'series': '52', 'year': 2007, 'volume_number': 1, 'special_version': None, 'issue_number': 10.0, 'annual': False},
+
+            '100 Bullets #1 (1999)':
+                {'series': '100 Bullets', 'year': 1999, 'volume_number': 1, 'special_version': None, 'issue_number': 1.0, 'annual': False}
+        }
+        self.run_cases(cases)
     # autopep8: on


### PR DESCRIPTION
Contributing request: #361.

A title that is, or begins with, a number had that number taken as its issue
number:

```python
extract_filename_data("2000AD")   # {'series': '', ..., 'issue_number': 2000.0104}
extract_filename_data("2000 AD")  # {'series': '', ..., 'issue_number': 2000.0}
extract_filename_data("52")       # {'series': '', ..., 'issue_number': 52.0}
```

With the issue number at position 0, `series_pos` is 0 — falsy — so the series
lookup falls through to the foldername, and a bare search-result title has no
folder. The result is an empty series, which fails `match_title`, which fails
`download_group_filter`, so a matching download group is discarded and the
search reports `NO_MATCHES`.

## What changed

No regex changes. One condition at the end of `extract_filename_data`: if the
series came out empty, the issue number was found at position 0, and the number
is not separated from the rest by a dash, then the number belongs to the series
name. The issue number is cleared and the special version falls back to TPB, as
it does for any other file without an issue number.

The dash check keeps the `5 - Title` form working exactly as before — that one
legitimately puts an issue number at the start and relies on the folder for the
series name.

`issue_end` is now tracked alongside `issue_pos` so the character after the
match can be inspected.

## Verification

`2000AD` and `52` now come out as series names, while `2000AD #2493 (2026)`,
`52 #10 (2007)` and `100 Bullets #1 (1999)` parse as before. New cases in
`test_numeric_series_name`; the existing suite passes unchanged. `mypy`, `isort`
and `autopep8` are clean.

Per CONTRIBUTING I know this function is your territory — happy for you to take
it over instead, the repro is in #361.
