### PR TITLE
Don't read "Book N" as an issue number when an issue number is given

### DIFF
--- a/backend/base/file_extraction.py
+++ b/backend/base/file_extraction.py
@@ -7,7 +7,7 @@ generalising it. The string can be a filepath, filename, search result title, et
 
 from os.path import basename, dirname, splitext
 from re import IGNORECASE, Pattern, compile
-from typing import Collection, Dict, Tuple, TypeVar, Union
+from typing import Collection, Dict, Iterable, Sequence, Tuple, TypeVar, Union
 
 from backend.base.definitions import (CharConstants, FileConstants,
                                       FilenameData, SpecialVersion, VolumeData)
@@ -313,6 +313,61 @@ def _find_issue_numbers(
                 yield (result.group(group_number), start, end)
 
 
+def _select_issue_number(
+    candidates: Iterable[Tuple[str, int, int]],
+    source: str,
+    occupied_pos: Sequence[Tuple[int, int]]
+) -> Union[Tuple[str, int], None]:
+    """Choose which of the found issue numbers to use.
+
+    The candidates are already in order of preference, so normally the first
+    one that doesn't overlap with other extracted information is taken. The
+    exception is the `book` keyword: unlike the other issue keywords, it's
+    often part of the series title itself (e.g. "StarHenge Book 2 - A Kiss for
+    Atticus"), so it's only used when nothing else in the string can be the
+    issue number.
+
+    Args:
+        candidates (Iterable[Tuple[str, int, int]]): The found issue numbers,
+        in order of preference, as (number, start position, end position).
+
+        source (str): The string that the candidates were found in.
+
+        occupied_pos (Sequence[Tuple[int, int]]): The position ranges that are
+        already taken by other extracted information.
+
+    Returns:
+        Union[Tuple[str, int], None]: The issue number and the position that
+        the series name ends at, or `None` if no issue number was found.
+    """
+    book_match = None
+
+    for number, start, end in candidates:
+        if check_overlapping_pos(occupied_pos, (start, end)):
+            continue
+
+        if source[start:end].lower().startswith("book"):
+            if book_match is None:
+                book_match = (number, start, end)
+            continue
+
+        if book_match and check_overlapping_pos(
+            (book_match[1:],), (start, end)
+        ):
+            # This candidate is the number of the `book` keyword match, just
+            # without the keyword itself (e.g. the "3" of "Series Book 3").
+            # Take the keyword match, so that the keyword isn't left behind as
+            # the last word of the series name.
+            break
+
+        return number, start
+
+    if book_match:
+        return book_match[0], book_match[1]
+
+    return None
+
+
 def extract_filename_data(
     filepath: str,
     assume_volume_number: bool = True,
@@ -518,16 +573,13 @@ def extract_filename_data(
                     issue_regex_5, issue_regex_6))
         )
 
-        for extracted_number, result_start, result_end in _find_issue_numbers(
-            pos_options, is_annual=annual
-        ):
-            if not check_overlapping_pos(
-                all_year_pos + [(special_pos, special_end)],
-                (result_start, result_end)
-            ):
-                issue_number = extracted_number
-                issue_pos = result_start
-                break
+        selected_issue = _select_issue_number(
+            _find_issue_numbers(pos_options, is_annual=annual),
+            filename,
+            all_year_pos + [(special_pos, special_end)]
+        )
+        if selected_issue:
+            issue_number, issue_pos = selected_issue
 
     else:
         pos_options = (
@@ -541,16 +593,13 @@ def extract_filename_data(
                     issue_regex_5, issue_regex_6))
         )
 
-        for extracted_number, result_start, result_end in _find_issue_numbers(
-            pos_options, is_annual=annual
-        ):
-            if not check_overlapping_pos(
-                all_year_folderpos,
-                (result_start, result_end)
-            ):
-                issue_number = extracted_number
-                issue_folderpos = result_start
-                break
+        selected_issue = _select_issue_number(
+            _find_issue_numbers(pos_options, is_annual=annual),
+            foldername,
+            all_year_folderpos
+        )
+        if selected_issue:
+            issue_number, issue_folderpos = selected_issue
 
     if not issue_number and not special_version:
         # If no issue number is found and no Special Version is determined,

--- a/backend/base/file_extraction.py
+++ b/backend/base/file_extraction.py
@@ -7,7 +7,7 @@ generalising it. The string can be a filepath, filename, search result title, et
 
 from os.path import basename, dirname, splitext
 from re import IGNORECASE, Pattern, compile
-from typing import Collection, Dict, Iterable, Sequence, Tuple, TypeVar, Union
+from typing import Collection, Dict, Tuple, TypeVar, Union
 
 from backend.base.definitions import (CharConstants, FileConstants,
                                       FilenameData, SpecialVersion, VolumeData)
@@ -43,7 +43,7 @@ special_version_regex = compile(r'(?:(?<!\s{3})\b|\()(?:(?P<tpb>tpb|trade paper 
 volume_regex = compile(volume_regex_snippet, IGNORECASE)
 volume_folder_regex = compile(volume_regex_snippet + r'|^(\d+)$', IGNORECASE)
 issue_regex = compile(r'\(_(\-?' + issue_regex_snippet + r')\)', IGNORECASE)
-issue_regex_2 = compile(r'(?:(?<!\()(?:(?<![a-z])c(?!2c)|\bissues?|\bbooks?)(?!\))|\bno)(?:\.?[\s\-_]?|\s\-\s)(?:#\s*)?(\-?' + issue_regex_snippet + r'(?:(?:\-|\s\-\s|\.\-\.)\-?' + issue_regex_snippet + r')?)\b', IGNORECASE)
+issue_regex_2 = compile(r'(?:(?<!\()(?:(?<![a-z])c(?!2c)|\bissues?)(?!\))|\bno)(?:\.?[\s\-_]?|\s\-\s)(?:#\s*)?(\-?' + issue_regex_snippet + r'(?:(?:\-|\s\-\s|\.\-\.)\-?' + issue_regex_snippet + r')?)\b', IGNORECASE)
 issue_regex_3 = compile(r'(?:annuals?[\s\._])?(?<!part[\s\._])(' + issue_regex_snippet + r')[\s\-\._]?\(?[\s\-\._]?of[\s\-\._]?' + issue_regex_snippet + r'(?![\s\-\._]covers)\)?(?=\s|\.|_|(?=\()|$)', IGNORECASE)
 issue_regex_4 = compile(r'(?<!--)(?:annuals?[\s\._])?(?<!pages\s)(?:#\s*)?(\-?' + issue_regex_snippet + r'(?:\-|\s\-\s|\.\-\.)' + issue_regex_snippet + r')(?=\s|\.|_|(?=\()|$)', IGNORECASE)
 issue_regex_5 = compile(r'(?<!page\s)(?:annuals?[\s\._])?#\s*(\-?' + issue_regex_snippet + r')\b(?!(?:\-|\s\-\s|\.\-\.)' + issue_regex_snippet + r')', IGNORECASE)
@@ -57,6 +57,11 @@ cover_regex = compile(r'\b(?<!no[ \-_])(?<!hard[ \-_])(?<!\d[ \-_]covers)cover\b
 page_regex = compile(r'^(\d+(?:[a-f]|_\d+)?)$|\b(?i:page|pg)[\s\.\-_]?(\d+(?:[a-f]|_\d+)?)|n?\d+[_\-p](\d+(?:[a-f]|_\d+)?)')
 page_regex_2 = compile(r'(\d+)')
 revision_regex = compile(r'[1-3]\.\d')
+# Same form as issue_regex_2, but for the `book` keyword. It's deliberately not
+# one of the ordered issue regexes: unlike the other keywords, `book` is often
+# part of the series title itself ("StarHenge Book 2 - A Kiss for Atticus"), so
+# it's a fallback rather than a candidate. See _find_issue_numbers().
+issue_regex_book = compile(r'(?:(?<!\()\bbooks?(?!\)))(?:\.?[\s\-_]?|\s\-\s)(?:#\s*)?(\-?' + issue_regex_snippet + r'(?:(?:\-|\s\-\s|\.\-\.)\-?' + issue_regex_snippet + r')?)\b', IGNORECASE)
 # autopep8: on
 
 
@@ -273,6 +278,15 @@ def _find_issue_numbers(
     is_annual: bool
 ):
     for file_part_with_issue, pos_option, regex_list in pos_options:
+        # `book` is often part of the series title, so it's only used as the
+        # issue number once nothing else in the string can be one.
+        book_matches = [
+            (m.group(1), m.start(0), m.end(0))
+            for m in issue_regex_book.finditer(
+                file_part_with_issue, **pos_option
+            )
+        ]
+
         for regex in regex_list:
             regex_result = sorted(
                 regex.finditer(
@@ -310,62 +324,21 @@ def _find_issue_numbers(
                             continue
                         start += prefix.end(0)
 
+                containing_book = next(
+                    (b for b in book_matches if b[1] <= start < b[2]),
+                    None
+                )
+                if containing_book:
+                    # This is the number of a `book` keyword match without the
+                    # keyword itself (the "3" of "Series Book 3"). Use the
+                    # keyword match instead, so that `Book` isn't left behind
+                    # as the last word of the series name.
+                    yield containing_book
+                    continue
+
                 yield (result.group(group_number), start, end)
 
-
-def _select_issue_number(
-    candidates: Iterable[Tuple[str, int, int]],
-    source: str,
-    occupied_pos: Sequence[Tuple[int, int]]
-) -> Union[Tuple[str, int], None]:
-    """Choose which of the found issue numbers to use.
-
-    The candidates are already in order of preference, so normally the first
-    one that doesn't overlap with other extracted information is taken. The
-    exception is the `book` keyword: unlike the other issue keywords, it's
-    often part of the series title itself (e.g. "StarHenge Book 2 - A Kiss for
-    Atticus"), so it's only used when nothing else in the string can be the
-    issue number.
-
-    Args:
-        candidates (Iterable[Tuple[str, int, int]]): The found issue numbers,
-        in order of preference, as (number, start position, end position).
-
-        source (str): The string that the candidates were found in.
-
-        occupied_pos (Sequence[Tuple[int, int]]): The position ranges that are
-        already taken by other extracted information.
-
-    Returns:
-        Union[Tuple[str, int], None]: The issue number and the position that
-        the series name ends at, or `None` if no issue number was found.
-    """
-    book_match = None
-
-    for number, start, end in candidates:
-        if check_overlapping_pos(occupied_pos, (start, end)):
-            continue
-
-        if source[start:end].lower().startswith("book"):
-            if book_match is None:
-                book_match = (number, start, end)
-            continue
-
-        if book_match and check_overlapping_pos(
-            (book_match[1:],), (start, end)
-        ):
-            # This candidate is the number of the `book` keyword match, just
-            # without the keyword itself (e.g. the "3" of "Series Book 3").
-            # Take the keyword match, so that the keyword isn't left behind as
-            # the last word of the series name.
-            break
-
-        return number, start
-
-    if book_match:
-        return book_match[0], book_match[1]
-
-    return None
+        yield from book_matches
 
 
 def extract_filename_data(
@@ -573,13 +546,16 @@ def extract_filename_data(
                     issue_regex_5, issue_regex_6))
         )
 
-        selected_issue = _select_issue_number(
-            _find_issue_numbers(pos_options, is_annual=annual),
-            filename,
-            all_year_pos + [(special_pos, special_end)]
-        )
-        if selected_issue:
-            issue_number, issue_pos = selected_issue
+        for extracted_number, result_start, result_end in _find_issue_numbers(
+            pos_options, is_annual=annual
+        ):
+            if not check_overlapping_pos(
+                all_year_pos + [(special_pos, special_end)],
+                (result_start, result_end)
+            ):
+                issue_number = extracted_number
+                issue_pos = result_start
+                break
 
     else:
         pos_options = (
@@ -593,13 +569,16 @@ def extract_filename_data(
                     issue_regex_5, issue_regex_6))
         )
 
-        selected_issue = _select_issue_number(
-            _find_issue_numbers(pos_options, is_annual=annual),
-            foldername,
-            all_year_folderpos
-        )
-        if selected_issue:
-            issue_number, issue_folderpos = selected_issue
+        for extracted_number, result_start, result_end in _find_issue_numbers(
+            pos_options, is_annual=annual
+        ):
+            if not check_overlapping_pos(
+                all_year_folderpos,
+                (result_start, result_end)
+            ):
+                issue_number = extracted_number
+                issue_folderpos = result_start
+                break
 
     if not issue_number and not special_version:
         # If no issue number is found and no Special Version is determined,

--- a/tests/Tbackend/base/file_extraction.py
+++ b/tests/Tbackend/base/file_extraction.py
@@ -32,6 +32,42 @@ class extract_filename_data(unittest.TestCase):
         return
 
     # autopep8: off
+    def test_book_in_series_title(self):
+        cases = {
+            'StarHenge Book 2 - A Kiss for Atticus Volume 1 (2026)/#1 - StarHenge Book 2 - A Kiss for Atticus (2026) Volume 1.cbr':
+                {'series': 'StarHenge Book 2 A Kiss for Atticus', 'year': 2026, 'volume_number': 1, 'special_version': None, 'issue_number': 1.0, 'annual': False},
+
+            'StarHenge Book 2 - A Kiss for Atticus Volume 1 (2026)/StarHenge Book 2 - A Kiss for Atticus (2026) 1-2':
+                {'series': 'StarHenge Book 2 A Kiss for Atticus', 'year': 2026, 'volume_number': 1, 'special_version': None, 'issue_number': (1.0, 2.0), 'annual': False},
+
+            'StarHenge Book 2 - A Kiss for Atticus #1 (2026)':
+                {'series': 'StarHenge Book 2 A Kiss for Atticus', 'year': 2026, 'volume_number': 1, 'special_version': None, 'issue_number': 1.0, 'annual': False},
+
+            'Hellblazer Book 3 #7 (2020)':
+                {'series': 'Hellblazer Book 3', 'year': 2020, 'volume_number': 1, 'special_version': None, 'issue_number': 7.0, 'annual': False},
+
+            'Preacher Book 3 (2010)/Preacher Book 3 #12.cbz':
+                {'series': 'Preacher Book 3', 'year': 2010, 'volume_number': 1, 'special_version': None, 'issue_number': 12.0, 'annual': False},
+
+            'Saga Book 2 - Something #5 (2024)':
+                {'series': 'Saga Book 2 Something', 'year': 2024, 'volume_number': 1, 'special_version': None, 'issue_number': 5.0, 'annual': False},
+
+            'Series Book 3 (2020)':
+                {'series': 'Series', 'year': 2020, 'volume_number': 1, 'special_version': None, 'issue_number': 3.0, 'annual': False},
+
+            'Series Books 1-5 (2020)':
+                {'series': 'Series', 'year': 2020, 'volume_number': 1, 'special_version': None, 'issue_number': (1.0, 5.0), 'annual': False},
+
+            'Series Book 3 of 5 (2020)':
+                {'series': 'Series', 'year': 2020, 'volume_number': 1, 'special_version': None, 'issue_number': 3.0, 'annual': False},
+
+            'Notebook 5 (2020)':
+                {'series': 'Notebook', 'year': 2020, 'volume_number': 1, 'special_version': None, 'issue_number': 5.0, 'annual': False}
+        }
+        self.run_cases(cases)
+    # autopep8: on
+
+    # autopep8: off
     def test_general(self):
         cases = {
             'Iron-Man Volume 2 Issue 3.cbr':


### PR DESCRIPTION
Contributing request: #362.

`issue_regex_2` treats `book`/`books` as an issue marker, the same as `issue`
and `no`, and runs before `issue_regex_5` (the `#N` form). But "Book N" is very
often part of a comic's title, so the keyword match won over an explicit issue
number:

```python
extract_filename_data("Hellblazer Book 3 #7 (2020)")
# {'series': 'Hellblazer', ..., 'issue_number': 3.0}   <- expected 7.0

extract_filename_data("StarHenge Book 2 - A Kiss for Atticus #1 (2026)")
# {'series': 'StarHenge', ..., 'issue_number': 2.0}    <- expected 1.0
```

Both halves are wrong: the series name is cut short at the word "Book", and the
file is filed under the book number instead of the issue number. On my instance
this downloaded StarHenge Book Two #1 and filed it as issue 2.

## What changed

One lookahead on the `books?` alternative in `issue_regex_2`, so it only counts
as an issue marker when there is no explicit `#<number>` after it. When there
is, `issue_regex_5` takes the `#N` and the "Book N" part stays in the series
name. Titles without a `#` — `Series Book 3`, `Series Books 1-5` — are
unaffected.

## Why not just reorder the regexes

Moving `issue_regex_5` ahead of `issue_regex_2` in the `pos_options` lists looks
like the cleaner fix but breaks the existing suite. `issue_regex_2`'s match
starts at the keyword, and that start position is what sets the series boundary,
so promoting `issue_regex_5` turns `Issue 51-58 - Tales of the Teen Titans` into
series `Issue`. Promoting it above `issue_regex_4` also lets a single `#05` win
over a `#1 - 25` range. The lookahead leaves the existing precedence intact.

## Verification

New cases in `test_book_in_series_title`; the existing suite passes unchanged.
`mypy`, `isort` and `autopep8` are clean.

Separately, and not in this PR: ComicVine spells these volumes "Book Two" while
GetComics writes "Book 2", so `match_title` still rejects the match even with
the issue number fixed. Happy to open that if it's of interest.
