### PR TITLE
Fixed naming collisions in new volume folders

### DIFF
--- a/backend/implementations/naming.py
+++ b/backend/implementations/naming.py
@@ -677,10 +677,11 @@ def same_name_indexing(
     Returns:
         Dict[str, str]: The planned renames, now updated with numbers if needed.
     """
-    if not isdir(volume_folder):
-        return planned_renames
-
-    final_names = set(list_files(volume_folder))
+    final_names = (
+        set(list_files(volume_folder))
+        if isdir(volume_folder)
+        else set()
+    )
     for before, after in planned_renames.items():
         new_after = after
         index = 1

--- a/tests/Tbackend/naming.py
+++ b/tests/Tbackend/naming.py
@@ -1,0 +1,24 @@
+import unittest
+from os.path import join
+from tempfile import TemporaryDirectory
+
+from backend.implementations.naming import same_name_indexing
+
+
+class SameNameIndexing(unittest.TestCase):
+    def test_collision_in_nonexistent_folder(self):
+        with TemporaryDirectory() as temporary_folder:
+            volume_folder = join(temporary_folder, 'new-volume')
+            destination = join(volume_folder, 'name.cbz')
+            planned_renames = {
+                join(temporary_folder, 'first.cbz'): destination,
+                join(temporary_folder, 'second.cbz'): destination
+            }
+
+            result = same_name_indexing(volume_folder, planned_renames)
+
+            self.assertIs(result, planned_renames)
+            self.assertEqual(
+                list(result.values()),
+                [destination, join(volume_folder, 'name (1).cbz')]
+            )


### PR DESCRIPTION
Fixes Mass Rename generating duplicate destination filenames when moving a volume into a folder that does not yet exist.

Planned destinations are now indexed in insertion order, producing `name.cbz`, `name (1).cbz`, and so on. Includes focused regression coverage for the new-folder case.