### PR TITLE
A failed conversion must not delete the file it was given

### DIFF
--- a/backend/implementations/converters.py
+++ b/backend/implementations/converters.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 from functools import lru_cache
 from itertools import chain
 from os import utime
-from os.path import basename, dirname, getmtime, join, splitext
+from os.path import basename, dirname, getmtime, isfile, join, splitext
 from typing import Dict, List, Set, Tuple, Union
 from zipfile import ZipFile
 
@@ -288,6 +288,59 @@ class ConvertersManager:
         return None
 
 
+def conversion_failed(
+    source: str,
+    target: str,
+    workspace: Union[str, None] = None,
+    detail: str = ''
+) -> List[str]:
+    """Abandon a conversion, leaving the file it was given untouched.
+
+    A converter that cannot produce its target must not destroy its
+    source. `rar_to_zip` extracts, zips and then deletes the original
+    without checking that the extraction worked -- and `run_rar` returns
+    a `CompletedProcess` whose return code nothing looked at. When rar
+    fails it leaves the folder empty, and `create_zip_archive` on an
+    empty folder writes a valid ZIP with no entries: 22 bytes, an
+    end-of-central-directory record and nothing else. The file record is
+    then repointed at that stub and the source removed, so the issue
+    counts as complete and the comic is gone.
+
+    Args:
+        source (str): The file the converter was given, which is kept.
+
+        target (str): What it was trying to produce, removed if a partial
+            or empty one was made.
+
+        workspace (Union[str, None], optional): A scratch folder to clean
+            up. Defaults to None.
+
+        detail (str, optional): What went wrong, for the log.
+            Defaults to ''.
+
+    Returns:
+        List[str]: The source, unchanged, as the conversion's result.
+    """
+    LOGGER.error(
+        "Could not convert %s%s. Leaving the original alone.",
+        source, f': {detail}' if detail else ''
+    )
+    if target and isfile(target):
+        delete_file_folder(target)
+    if workspace:
+        delete_file_folder(workspace)
+    return [source]
+
+
+def archive_is_empty(filepath: str) -> bool:
+    "Whether a ZIP archive was written with nothing in it."
+    try:
+        with ZipFile(filepath, 'r') as archive:
+            return not archive.namelist()
+    except Exception:
+        return True
+
+
 # region ZIP
 @ConvertersManager.register_converter("zip", "cbz")
 def zip_to_cbz(file: str) -> List[str]:
@@ -312,7 +365,7 @@ def zip_to_rar(file: str) -> List[str]:
     with ZipFile(file, 'r') as zip:
         zip.extractall(archive_folder)
 
-    run_rar([
+    result = run_rar([
         'a', # Add files to archive
         '-ep', # Exclude paths from names
         '-inul', # Disable all messages
@@ -320,11 +373,18 @@ def zip_to_rar(file: str) -> List[str]:
         archive_folder # Source folder
     ])
 
+    target_file = splitext(file)[0] + '.rar'
+    if result.returncode != 0 or not isfile(target_file):
+        return conversion_failed(
+            file, target_file, archive_folder,
+            f'rar exited {result.returncode} and wrote no archive'
+        )
+
     delete_file_folder(archive_folder)
     delete_file_folder(file)
     delete_empty_parent_folders(dirname(file), volume_folder)
 
-    return [splitext(file)[0] + '.rar']
+    return [target_file]
 
 
 @ConvertersManager.register_converter("zip", "cbr", supports_32bit=False)
@@ -421,12 +481,18 @@ def rar_to_zip(file: str) -> List[str]:
     archive_folder = generate_archive_folder(volume_folder, file)
     create_folder(archive_folder)
 
-    run_rar([
+    result = run_rar([
         'x', # Extract files with full path
         '-inul', # Disable all messages
         file, # Source archive file
         archive_folder # Target folder to extract into
     ])
+
+    if result.returncode != 0 or not list_files(archive_folder):
+        return conversion_failed(
+            file, '', archive_folder,
+            f'rar exited {result.returncode} and extracted nothing'
+        )
 
     # Files that are put in a ZIP file have to have a minimum last
     # modification time.
@@ -439,6 +505,12 @@ def rar_to_zip(file: str) -> List[str]:
 
     target_file = splitext(file)[0] + '.zip'
     create_zip_archive(archive_folder, target_file)
+
+    if archive_is_empty(target_file):
+        return conversion_failed(
+            file, target_file, archive_folder,
+            'the archive it wrote holds nothing'
+        )
 
     delete_file_folder(archive_folder)
     delete_file_folder(file)

--- a/tests/Tbackend/converters.py
+++ b/tests/Tbackend/converters.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+
+"""A failed conversion must not delete the file it was given.
+
+`rar_to_zip` extracts a `.cbr` into a scratch folder, zips that folder and
+then deletes the original, without checking that the extraction worked --
+`run_rar` returns a `CompletedProcess` and nothing looks at its return
+code. When rar fails it leaves the folder empty, and `create_zip_archive`
+on an empty folder writes a valid ZIP with no entries: exactly 22 bytes,
+an end-of-central-directory record and nothing else. The file record is
+then repointed at that stub and the source removed, so the issue counts as
+complete and holds no comic.
+
+`zip_to_rar` has the same shape and one worse consequence: it deletes the
+source and returns a path to a `.rar` it never confirmed exists.
+"""
+
+import os
+import tempfile
+import unittest
+import zipfile
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from backend.implementations import converters
+
+
+class _Rar:
+    "Stands in for `run_rar`, which returns a CompletedProcess."
+
+    def __init__(self, returncode=0, writes=None):
+        self.returncode = returncode
+        self.writes = writes or {}
+
+    def __call__(self, args):
+        for path, content in self.writes.items():
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with open(path, 'wb') as f:
+                f.write(content)
+        return SimpleNamespace(returncode=self.returncode, stdout='', stderr='')
+
+
+class a_failed_extraction_keeps_the_original(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.volume_folder = os.path.join(self.tmp.name, 'volume')
+        self.workspace = os.path.join(self.tmp.name, 'extract')
+        os.makedirs(self.volume_folder)
+
+        self.source = os.path.join(self.volume_folder, 'Comic 001.cbr')
+        with open(self.source, 'wb') as f:
+            f.write(b'Rar!\x1a\x07\x00' + b'x' * 4096)
+
+        for target, value in (
+            ('FilesDB', SimpleNamespace(volume_of_file=lambda f: 1)),
+            ('Volume', lambda vid: SimpleNamespace(
+                vd=SimpleNamespace(folder=self.volume_folder))),
+            ('generate_archive_folder', lambda vf, f: self.workspace),
+        ):
+            patcher = patch.object(converters, target, value)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+
+    def _rar(self, rar):
+        return patch.object(converters, 'run_rar', rar)
+
+    def test_a_nonzero_exit_leaves_the_comic_alone(self):
+        with self._rar(_Rar(returncode=3)):
+            result = converters.rar_to_zip(self.source)
+
+        self.assertEqual(result, [self.source])
+        self.assertTrue(os.path.isfile(self.source))
+        self.assertEqual(os.path.getsize(self.source), 4103)
+
+    def test_an_extraction_that_produced_nothing_leaves_it_alone(self):
+        with self._rar(_Rar(returncode=0)):
+            result = converters.rar_to_zip(self.source)
+
+        self.assertEqual(result, [self.source])
+        self.assertTrue(os.path.isfile(self.source))
+
+    def test_no_empty_archive_is_left_behind(self):
+        with self._rar(_Rar(returncode=0)):
+            converters.rar_to_zip(self.source)
+
+        stub = os.path.join(self.volume_folder, 'Comic 001.zip')
+        self.assertFalse(os.path.exists(stub))
+        self.assertFalse(os.path.exists(self.workspace))
+
+    def test_a_real_extraction_still_converts(self):
+        page = os.path.join(self.workspace, 'page01.jpg')
+        with self._rar(_Rar(returncode=0, writes={page: b'\xff\xd8' * 200})):
+            result = converters.rar_to_zip(self.source)
+
+        target = os.path.join(self.volume_folder, 'Comic 001.zip')
+        self.assertEqual(result, [target])
+        self.assertTrue(os.path.isfile(target))
+        self.assertFalse(os.path.exists(self.source))
+        with zipfile.ZipFile(target) as archive:
+            self.assertEqual(archive.namelist(), ['page01.jpg'])
+
+
+class an_empty_archive_is_recognised(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+
+    def _zip(self, name, entries):
+        path = os.path.join(self.tmp.name, name)
+        with zipfile.ZipFile(path, 'w') as archive:
+            for entry in entries:
+                archive.writestr(entry, b'x')
+        return path
+
+    def test_an_archive_with_no_entries(self):
+        path = self._zip('empty.cbz', [])
+        self.assertEqual(os.path.getsize(path), 22)
+        self.assertTrue(converters.archive_is_empty(path))
+
+    def test_an_archive_with_a_page_in_it(self):
+        self.assertFalse(
+            converters.archive_is_empty(self._zip('ok.cbz', ['page01.jpg']))
+        )
+
+    def test_something_that_is_not_an_archive_at_all(self):
+        path = os.path.join(self.tmp.name, 'broken.cbz')
+        with open(path, 'wb') as f:
+            f.write(b'not a zip')
+        self.assertTrue(converters.archive_is_empty(path))


### PR DESCRIPTION
`rar_to_zip` extracts a `.cbr` into a scratch folder, zips that folder and then deletes the original, without ever checking that the extraction worked. `run_rar` returns a `CompletedProcess` and nothing looks at its return code.

When rar fails it leaves the folder empty, and `create_zip_archive` on an empty folder writes a valid ZIP with no entries: exactly 22 bytes, an end-of-central-directory record and nothing else. The file record is then repointed at that stub and the source removed, so the issue counts as complete and holds no comic.

I found twenty of these in my library, all `.cbz`, all 22 bytes. The clearest was an Adam Strange issue whose 16MB `.cbr` was still sitting in the download folder being fetched again and again, because the volume looked like it already had that issue.

`zip_to_rar` has the same shape and one worse consequence: it deletes the source and returns a path to a `.rar` it never confirmed exists.

Both now check the exit code and that something was actually produced, and the ZIP written is checked for entries before the source is deleted. Where any of that fails the original is kept, the stub removed, and the reason logged. The working path is unchanged.