### PR TITLE
Do not let an invented volume number decide the match on its own

### DIFF
--- a/backend/implementations/file_matching.py
+++ b/backend/implementations/file_matching.py
@@ -125,7 +125,17 @@ def scan_files(
             )
             continue
 
-        file_data = extract_filename_data(file)
+        # Don't let the parser invent a volume number. Most files don't name
+        # one, and most volumes are volume 1, so an assumed 1 acts as a match
+        # for a series' volume-1 entry and a mismatch for every other one.
+        # For a VAI volume the volume number is the issue number, so the
+        # assumption is still doing real work there and is left alone.
+        file_data = extract_filename_data(
+            file,
+            assume_volume_number=(
+                volume_data.special_version == SpecialVersion.VOLUME_AS_ISSUE
+            )
+        )
 
         # Check if file matches volume
         if not file_importing_filter(

--- a/backend/implementations/matching.py
+++ b/backend/implementations/matching.py
@@ -329,11 +329,22 @@ def file_importing_filter(
         number_to_year.get(force_range(issue_number)[-1])
     )
 
+    # The name stated neither a volume number nor a year, so there is nothing
+    # here to place the file in one volume of a series rather than another.
+    # `Detective.Comics.962.cbz` is the shape of it: Detective Comics (2016) is
+    # volume 3 and holds #934-1112, and the file names neither. Rule nothing in
+    # or out on that absence, and let the issue number do the work.
+    nothing_stated = (
+        file_data['volume_number'] is None
+        and file_data['year'] is None
+    )
+
     is_match = (
         matching_special_version
         and (
             matching_volume_number
             or matching_year
+            or nothing_stated
         )
     )
 

--- a/tests/Tbackend/implementations/matching.py
+++ b/tests/Tbackend/implementations/matching.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+
+"""A volume number the filename never stated should not decide the match.
+
+The fixtures are two real ComicVine volumes of one series:
+
+    Detective Comics (1937)  volume 1  issues 1..881
+    Detective Comics (2016)  volume 3  issues 934..1112
+
+Issue 962 exists in exactly one of them, and a file named
+`Detective.Comics.962.cbz` could only ever reach the other one.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from backend.base.definitions import SpecialVersion
+from backend.base.file_extraction import extract_filename_data
+from backend.implementations.matching import file_importing_filter
+
+
+def _volume(year, volume_number, first_issue, issue_count):
+    volume_data = SimpleNamespace(
+        id=1, comicvine_id=1, title='Detective Comics', alt_title=None,
+        year=year, volume_number=volume_number, description='', site_url='',
+        publisher='DC', monitored=True, monitor_new_issues=True,
+        root_folder=1, folder=f'/library/Detective Comics ({year})',
+        custom_folder=False, special_version=SpecialVersion.NORMAL,
+        special_version_locked=False, last_cv_fetch=0
+    )
+    issues = [
+        SimpleNamespace(calculated_issue_number=float(n), date=None)
+        for n in range(first_issue, first_issue + issue_count)
+    ]
+    number_to_year = {i.calculated_issue_number: None for i in issues}
+    return volume_data, issues, number_to_year
+
+
+DETECTIVE_1937 = _volume(1937, 1, 1, 881)
+DETECTIVE_2016 = _volume(2016, 3, 934, 179)
+
+
+def _accepts(filename, volume):
+    volume_data, issues, number_to_year = volume
+    # `scan_files` reads names this way for a non-VAI volume.
+    file_data = extract_filename_data(filename, assume_volume_number=False)
+    return file_importing_filter(
+        file_data, volume_data, issues, number_to_year
+    )
+
+
+class file_importing_filter_volume_number(unittest.TestCase):
+    def test_name_stating_nothing_reaches_every_volume(self):
+        """A name that states neither a volume number nor a year says nothing
+        about which volume of the series it belongs to, so the filter must not
+        rule any of them out on that absence."""
+        self.assertTrue(_accepts('Detective.Comics.962.cbz', DETECTIVE_2016))
+        self.assertTrue(_accepts('Detective.Comics.962.cbz', DETECTIVE_1937))
+
+    def test_stated_volume_number_still_decides(self):
+        """A volume number the name does state is real evidence, and still
+        rules the other volumes out."""
+        self.assertTrue(
+            _accepts('Detective Comics Vol. 3 962.cbz', DETECTIVE_2016)
+        )
+        self.assertFalse(
+            _accepts('Detective Comics Vol. 3 962.cbz', DETECTIVE_1937)
+        )
+
+    def test_stated_year_still_decides(self):
+        """A year the name does state is real evidence, in both directions."""
+        self.assertTrue(
+            _accepts('Detective Comics (1937) 962.cbz', DETECTIVE_1937)
+        )
+        self.assertFalse(
+            _accepts('Detective Comics (1937) 962.cbz', DETECTIVE_2016)
+        )
+        self.assertTrue(
+            _accepts('Detective Comics (2016) 962.cbz', DETECTIVE_2016)
+        )
+        self.assertFalse(
+            _accepts('Detective Comics (2016) 962.cbz', DETECTIVE_1937)
+        )


### PR DESCRIPTION
`extract_filename_data` fills in `volume_number = 1` when a filename does not state one, and most filenames do not. Almost every volume in a comics library is also volume 1, so `match_volume_number` says yes to those entries and no to every other entry of the same series -- on the strength of a number the file never carried.

Where the name states a year as well, `match_year` still has something real to say. Where it states neither, that invented number is the only thing deciding, and it decides by catalogue accident.

From my library:

    Detective Comics (1937)  volume 1  issues 1..881
    Detective Comics (2017)  volume 1  issues 1..30
    Detective Comics (2016)  volume 3  issues 934..1112

`Detective.Comics.962.cbz` states no year and no volume. Issue 962 is in exactly one of those three, and it is the one the file could not reach -- Detective Comics (2016) is volume 3. What it could reach was the 1937 volume, which stops at #881.

So where a name states neither a year nor a volume number, that clause now rules nothing in or out. A file that then matches more than one volume is ambiguous, and the callers already leave those alone, which is the outcome to prefer over a confident wrong folder. A name that does say `v1` is still a claim, and volume 3 still refuses it.

The parser records whether the volume number was its own default, so "stated 1" and "assumed 1" stop being the same thing. The key is optional on `FilenameData`, so the places building it as a literal are unaffected.

`tests/Tbackend/file_extraction.py` compares whole dictionaries, so its helper now drops that one annotation key before comparing -- named explicitly rather than ignoring unknown keys, so the comparison stays exhaustive over every field those tables are actually about.