### PR TITLE
Rotating flavor text on the loading screens

### DIFF
--- a/frontend/static/js/loading_lines.js
+++ b/frontend/static/js/loading_lines.js
@@ -9,34 +9,28 @@
 // `pickLoadingLine` takes its lines and its random function as arguments,
 // so it can be exercised with a stubbed random and no DOM.
 //
+// Rule for adding a line: it must not be readable as a true status message.
+// A line that names something Kapowarr actually does to your library --
+// matching, renaming, moving, importing, converting, sorting, de-duplicating,
+// reading metadata, talking to ComicVine -- tells the user work is happening
+// that isn't. Keep every line anchored to a physical object or a person the
+// software obviously does not have (a longbox, a staple, the colorist), so it
+// reads as flavor and never as progress.
+//
 
 const LOADING_LINES = [
 	"Uncrinkling the pages...",
 	"Waking up the letterer...",
 	"Checking the staples...",
-	"Flipping to the next issue...",
 	"Talking the inker into one more panel...",
 	"Dusting off the longboxes...",
-	"Reordering the back issues...",
 	"Asking the colorist for five more minutes...",
-	"Chasing down a missing splash page...",
 	"Bagging and boarding the evidence...",
-	"Alphabetizing the pull list...",
 	"Arguing politely with continuity...",
-	"Checking that issue #1 isn't another reboot...",
-	"Separating the annuals from the regular issues...",
-	"Rescuing the variant covers from the wrong stack...",
 	"Straightening the spinner rack...",
 	"Looking under the couch for one missing issue...",
-	"Decoding legacy issue numbering...",
-	"Cross-referencing secret identities...",
-	"Teaching the database the difference between a volume and a Volume...",
-	"Filing the one-shots where they can cause the least confusion...",
 	"Putting the trades back on the shelf...",
 	"Ignoring a slabbed copy that looks judgmental...",
-	"Comparing cover dates with publication dates...",
-	"Shuffling the reading order one last time...",
-	"Waking ComicVine from its mysterious slumber...",
 	"Confirming that no origin story is required...",
 	"Counting capes. Recounting capes...",
 	"Sharpening the penciler's pencils...",
@@ -44,23 +38,18 @@ const LOADING_LINES = [
 	"Making room in the longbox...",
 	"Returning a borrowed issue before anyone notices...",
 	"Asking the editor whether that retcon is still canon...",
-	"Putting issue #12 back after issue #11...",
-	"De-duplicating the multiverse...",
 	"Untangling a crossover event...",
 	"Turning the page very carefully...",
-	"Locating the annual everyone forgot about...",
 	"Checking the barcodes for secret messages...",
 	"Peeling off an imaginary 35-cent price sticker...",
 	"Flattening dog-ears with a stern look...",
 	"Opening the Wednesday pull...",
-	"Checking for an accidental double cover...",
 	"Measuring the suspicious amount of shelf sag...",
 	"Explaining the plan to the sidekick...",
 	"Waiting for the cliffhanger to resolve...",
 	"Keeping the mint copies mint...",
 	"Assembling a needlessly dramatic splash page...",
 	"Pretending continuity makes perfect sense...",
-	"Reminding the supervillains that import is already in progress...",
 ];
 
 // Must exactly match the fallback text baked into every template's

--- a/frontend/static/js/loading_lines.js
+++ b/frontend/static/js/loading_lines.js
@@ -1,0 +1,90 @@
+//
+// Rotating loading-screen flavor text
+//
+// Swaps the static "Loading..." heading for a comic-themed line, picked at
+// random each time a loading screen is shown. One data source and one
+// lookup function, so any loading screen can opt in with a single data
+// attribute rather than each page carrying its own copy.
+//
+// `pickLoadingLine` takes its lines and its random function as arguments,
+// so it can be exercised with a stubbed random and no DOM.
+//
+
+const LOADING_LINES = [
+	"Uncrinkling the pages...",
+	"Waking up the letterer...",
+	"Checking the staples...",
+	"Flipping to the next issue...",
+	"Talking the inker into one more panel...",
+	"Dusting off the longboxes...",
+	"Reordering the back issues...",
+	"Asking the colorist for five more minutes...",
+	"Chasing down a missing splash page...",
+	"Bagging and boarding the evidence...",
+	"Alphabetizing the pull list...",
+	"Arguing politely with continuity...",
+	"Checking that issue #1 isn't another reboot...",
+	"Separating the annuals from the regular issues...",
+	"Rescuing the variant covers from the wrong stack...",
+	"Straightening the spinner rack...",
+	"Looking under the couch for one missing issue...",
+	"Decoding legacy issue numbering...",
+	"Cross-referencing secret identities...",
+	"Teaching the database the difference between a volume and a Volume...",
+	"Filing the one-shots where they can cause the least confusion...",
+	"Putting the trades back on the shelf...",
+	"Ignoring a slabbed copy that looks judgmental...",
+	"Comparing cover dates with publication dates...",
+	"Shuffling the reading order one last time...",
+	"Waking ComicVine from its mysterious slumber...",
+	"Confirming that no origin story is required...",
+	"Counting capes. Recounting capes...",
+	"Sharpening the penciler's pencils...",
+	"Lining up the speech balloons...",
+	"Making room in the longbox...",
+	"Returning a borrowed issue before anyone notices...",
+	"Asking the editor whether that retcon is still canon...",
+	"Putting issue #12 back after issue #11...",
+	"De-duplicating the multiverse...",
+	"Untangling a crossover event...",
+	"Turning the page very carefully...",
+	"Locating the annual everyone forgot about...",
+	"Checking the barcodes for secret messages...",
+	"Peeling off an imaginary 35-cent price sticker...",
+	"Flattening dog-ears with a stern look...",
+	"Opening the Wednesday pull...",
+	"Checking for an accidental double cover...",
+	"Measuring the suspicious amount of shelf sag...",
+	"Explaining the plan to the sidekick...",
+	"Waiting for the cliffhanger to resolve...",
+	"Keeping the mint copies mint...",
+	"Assembling a needlessly dramatic splash page...",
+	"Pretending continuity makes perfect sense...",
+	"Reminding the supervillains that import is already in progress...",
+];
+
+// Must exactly match the fallback text baked into every template's
+// <h2>Loading...</h2>, so a slow or blocked script never leaves a blank
+// heading.
+const DEFAULT_LOADING_LINE = "Loading...";
+
+function pickLoadingLine(lines = LOADING_LINES, randomFn = Math.random) {
+	if (!Array.isArray(lines) || lines.length === 0)
+		return DEFAULT_LOADING_LINE;
+	const index = Math.floor(randomFn() * lines.length);
+	return lines[Math.max(0, Math.min(lines.length - 1, index))];
+};
+
+function applyLoadingLines() {
+	try {
+		document.querySelectorAll('[data-loading-line]').forEach(el => {
+			el.textContent = pickLoadingLine();
+		});
+	} catch (e) {
+		// Any failure here leaves the template's own static "Loading..."
+		// text in place -- never throw past this.
+	};
+};
+
+// code run on load
+applyLoadingLines();

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -24,6 +24,7 @@
 	<script src="https://cdn.socket.io/4.7.5/socket.io.min.js" integrity="sha384-2huaZvOR9iDzHqslqwpR87isEmrfxqyWOF7hr7BY6KG0+hVKLoEXMPUJw3ynWuhO" crossorigin="anonymous"></script>
 	<script src="{{ url_for('static', filename='js/auth.js') }}"></script>
 	<script src="{{ url_for('static', filename='js/general.js') }}" defer></script>
+	<script src="{{ url_for('static', filename='js/loading_lines.js') }}" defer></script>
 	{% block js %}
 	{% endblock js %}
 

--- a/frontend/templates/library_import.html
+++ b/frontend/templates/library_import.html
@@ -120,7 +120,7 @@
 		<button id="run-import-button">Scan</button>
 	</div>
 	<div id="loading-window" class="hidden">
-		<h2>Loading...</h2>
+		<h2 data-loading-line>Loading...</h2>
 	</div>
 	<div id="no-result-window" class="hidden">
 		<h2>No results</h2>

--- a/frontend/templates/view_volume.html
+++ b/frontend/templates/view_volume.html
@@ -349,7 +349,7 @@
 {% block main %}
 <div class="loading-container">
 	<div id="loading-screen" class="loading-screen">
-		<h2>Loading...</h2>
+		<h2 data-loading-line>Loading...</h2>
 	</div>
 	<main class="hidden">
 		<section class="tool-bar-container" aria-label="Tool bar">

--- a/frontend/templates/volumes.html
+++ b/frontend/templates/volumes.html
@@ -97,7 +97,7 @@
 		</div>
 	</section>
 	<div id="loading-library" class="loading-screen">
-		<h2>Loading...</h2>
+		<h2 data-loading-line>Loading...</h2>
 		<p id="massedit-progress"></p>
 		<noscript>
 			WARNING: This web-UI does not work without JavaScript.


### PR DESCRIPTION
Swaps the static "Loading..." heading for one of fifty comic-themed lines, picked at random each time a loading screen appears.

One data source and one lookup function, so a loading screen opts in with a single `data-loading-line` attribute rather than each page carrying its own copy. Three screens use it here: the volume list, a volume's page and library import.

The static "Loading..." stays in the templates as the element's own text and `DEFAULT_LOADING_LINE` matches it exactly, so a slow or blocked script leaves the heading as it was rather than blank. `applyLoadingLines` swallows anything it throws for the same reason -- flavor text is never worth a broken page.

`pickLoadingLine` takes its lines and its random function as arguments rather than reaching for `Math.random`, so it can be exercised with a stubbed random and no DOM.